### PR TITLE
Add VCIO link to package vulnerability tab

### DIFF
--- a/component_catalog/tests/test_views.py
+++ b/component_catalog/tests/test_views.py
@@ -3192,7 +3192,7 @@ class PackageUserViewsTestCase(TestCase):
         copy_object(self.package1, Dataspace.objects.create(name="Other"), self.basic_user)
         get_vulnerability_fields = PackageDetailsView.get_vulnerability_fields
         fields = get_vulnerability_fields(vulnerability={}, dataspace=self.dataspace)
-        self.assertEqual(fields[0], ('Vulnerability URL', None, 'The URL of the Vulnerability'))
+        self.assertEqual(fields[0], ("Vulnerability URL", None, "The URL of the Vulnerability"))
         self.assertEqual(fields[1], ("Summary", None, "Summary of the vulnerability"))
         vulnerability = {
             "vulnerability_id": "VCID-a1md-ney4-aaac",
@@ -3214,15 +3214,22 @@ class PackageUserViewsTestCase(TestCase):
                 {"purl": "pkg:nginx/nginx@1.10.1"},
             ],
         }
-        self.dataspace.configuration = DataspaceConfiguration(vulnerablecode_url="https://public.vulnerablecode.io/")
+        self.dataspace.configuration = DataspaceConfiguration(
+            vulnerablecode_url="https://public.vulnerablecode.io/"
+        )
         fields = get_vulnerability_fields(
             vulnerability=vulnerability,
             dataspace=self.dataspace,
         )
-        self.assertEqual(fields[0], ('Vulnerability URL',
-        '<a href="https://public.vulnerablecode.io/vulnerabilities/VCID-a1md-ney4-aaac"'
-        ' target="_blank">VCID-a1md-ney4-aaac</a>',
-                                     'The URL of the Vulnerability'))
+        self.assertEqual(
+            fields[0],
+            (
+                "Vulnerability URL",
+                '<a href="https://public.vulnerablecode.io/vulnerabilities/VCID-a1md-ney4-aaac"'
+                ' target="_blank">VCID-a1md-ney4-aaac</a>',
+                "The URL of the Vulnerability",
+            ),
+        )
         self.assertEqual(fields[1], ("Summary", "SQL Injection", "Summary of the vulnerability"))
         self.assertEqual(fields[2][0], "Fixed packages")
         fixed_package_values = fields[2][1]

--- a/component_catalog/views.py
+++ b/component_catalog/views.py
@@ -287,6 +287,7 @@ class TabVulnerabilityMixin:
     @staticmethod
     def get_vulnerability_fields(vulnerability, dataspace):
         include_fixed_packages = "fixed_packages" in vulnerability.keys()
+        vulnerability_url = vulnerability.get("url")
         summary = vulnerability.get("summary")
         references = vulnerability.get("references", [])
 
@@ -307,6 +308,7 @@ class TabVulnerabilityMixin:
         reference_ids_joined = "\n".join(reference_ids)
 
         tab_fields = [
+            (_("Vulnerability URL"), vulnerability_url, "The URL of the vulnerability"),
             (_("Summary"), summary, "Summary of the vulnerability"),
         ]
 

--- a/component_catalog/views.py
+++ b/component_catalog/views.py
@@ -287,7 +287,6 @@ class TabVulnerabilityMixin:
     @staticmethod
     def get_vulnerability_fields(vulnerability, dataspace):
         include_fixed_packages = "fixed_packages" in vulnerability.keys()
-        vulnerability_url = vulnerability.get("url")
         summary = vulnerability.get("summary")
         references = vulnerability.get("references", [])
 
@@ -307,8 +306,21 @@ class TabVulnerabilityMixin:
         reference_urls_joined = "\n".join(reference_urls)
         reference_ids_joined = "\n".join(reference_ids)
 
+        vulnerability_id = vulnerability.get("vulnerability_id") or ""
+        vulnerability_url_tag = None
+        if vulnerability_id:
+            vulnerablecode_url_ds = dataspace.get_configuration().vulnerablecode_url
+            vulnerability_url = vulnerablecode_url_ds + "vulnerabilities/" + vulnerability_id
+            vulnerability_url_tag = format_html(
+                f'<a href="{vulnerability_url}" target="_blank">{vulnerability_id}</a>'
+            )
+
         tab_fields = [
-            (_("Vulnerability URL"), vulnerability_url, "The URL of the vulnerability"),
+            (
+                _("Vulnerability URL"),
+                vulnerability_url_tag,
+                "The URL of the Vulnerability",
+            ),
             (_("Summary"), summary, "Summary of the vulnerability"),
         ]
 


### PR DESCRIPTION
Issue:  #4

@DennisClark should we display the JSON response URL or the VCIO link :
ex:
http://public.vulnerablecode.io/api/vulnerabilities/457133?format=json

![image](https://github.com/nexB/dejacode/assets/29133904/4af2747d-dc0d-4295-934a-708ad0e0ceb3)
or 
https://public.vulnerablecode.io/vulnerabilities/VCID-z6fe-2j8a-aaak
![image](https://github.com/nexB/dejacode/assets/29133904/6b7216d6-e982-48ab-aa95-6101e158c00c)
