### PR TITLE
Use correct Makefile target name #75

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,4 +164,4 @@ log:
 createsuperuser:
 	${DOCKER_EXEC} web ./manage.py createsuperuser
 
-.PHONY: virtualenv conf dev envfile check bandit isort black doc8 valid check-docstrings check-deploy clean initdb postgresdb migrate run test docs build psql bash shell log createsuperuse
+.PHONY: virtualenv conf dev envfile check bandit isort black doc8 valid check-docstrings check-deploy clean initdb postgresdb migrate run test docs build psql bash shell log createsuperuser


### PR DESCRIPTION
Correct "createsuperuse" target name that is missing an r.
 
Reported-by: Stefan @stefan6419846
Reference: https://github.com/nexB/dejacode/issues/75
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>