### PR TITLE
BUG: Search field prompt on Browse Licenses is not accurate for owner #372

### DIFF
--- a/dje/admin.py
+++ b/dje/admin.py
@@ -432,7 +432,7 @@ class DataspacedChangeList(ChangeList):
     def get_search_fields_for_hint_display(self):
         if not self.search_fields:
             return []
-        return tuple(set(field.split("__")[0] for field in self.search_fields))
+        return tuple(set(field for field in self.search_fields))
 
 
 class DataspacedAdmin(


### PR DESCRIPTION
 This PR fixes the bug where the search field hint did not display the correct field for owner lookups. The hint now shows `owner__name` so users know to use the correct search syntax.

**Signed-off-by:**  
Your Name <anshulkhaire3303dll@gmail.com>

