### PR TITLE
Packaging for Fedora

### DIFF
--- a/etc/scripts/build_rpm_docker.py
+++ b/etc/scripts/build_rpm_docker.py
@@ -13,6 +13,12 @@ To run the script:
 
 This script will generate the RPM package files and place them in the
 dist/rpmbuild/ directory.
+
+Once the RPM package is generated, you can install it using:
+
+    sudo dnf install /path/to/<dejacode>.rpm
+
+(Replace the above path with the actual path to the generated RPM file.)
 """
 
 import os


### PR DESCRIPTION
Fixes https://github.com/aboutcode-org/dejacode/issues/340

Create a script that automates fedora packaging

Once the RPM package is generated, you can install it using:
```
sudo dnf install /path/to/<dejacode>.rpm
```
Replace the above path with the actual path to the generated RPM file.


Signed-off-by: Chin Yeung Li <tli@nexb.com>