### PR TITLE
Allow "Scan all packages" availability to "change_product" users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Release notes
   Inactive is_active=False products are excluded.
   https://github.com/aboutcode-org/dejacode/issues/388
 
+- Allow Product "Scan all packages" for users with the "change_product" permission
+  on the Product instance.
+  Prior to this change only "superusers" could see and use this feature.
+  https://github.com/aboutcode-org/dejacode/issues/385
+
 ### Version 5.4.2
 
 - Migrate the LDAP testing from using mockldap to slapdtest.

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -704,9 +704,9 @@ class ProductDetailsView(
         include_scancodeio_features = all(
             [
                 scancodeio.is_configured(),
-                user.is_superuser,
                 dataspace.enable_package_scanning,
                 context["is_user_dataspace"],
+                context["has_change_permission"],
             ]
         )
         context["has_scan_all_packages"] = include_scancodeio_features
@@ -1964,7 +1964,6 @@ def scan_all_packages_view(request, dataspace, name, version=""):
     scancodeio = ScanCodeIO(user_dataspace)
     conditions = [
         scancodeio.is_configured(),
-        user.is_superuser,
         user_dataspace.enable_package_scanning,
         user_dataspace.name == dataspace,
     ]
@@ -1972,9 +1971,8 @@ def scan_all_packages_view(request, dataspace, name, version=""):
     if not all(conditions):
         raise Http404
 
-    guarded_qs = Product.objects.get_queryset(user)
+    guarded_qs = Product.objects.get_queryset(user, perms="change_product")
     product = get_object_or_404(guarded_qs, name=unquote_plus(name), version=unquote_plus(version))
-
     if not product.all_packages:
         raise Http404("No packages available for this product.")
 


### PR DESCRIPTION
Issue: https://github.com/aboutcode-org/dejacode/issues/385
Allow Product "Scan all packages" for users with the "change_product" permission on a Product instance.
Before this change, only "superusers" could see and use this feature.