### PR TITLE
Packaging for Fedora

### DIFF
--- a/etc/scripts/build_rpm_docker.py
+++ b/etc/scripts/build_rpm_docker.py
@@ -80,12 +80,12 @@ def build_rpm_with_docker():
         "-c",
         f"""set -ex
 # Install build dependencies
-dnf install -y rpm-build python3-devel python3-setuptools python3-wheel \\
-    python3-build python3-pip python3-virtualenv curl gcc openldap-devel git
+dnf install -y rpm-build python3.13-devel python3.13-setuptools python3.13-wheel \\
+    python3.13-build python3.13-pip python3.13-virtualenv curl gcc openldap-devel git
 
 # Clean up and build wheel
 rm -rf build dist
-python3 -m build --wheel
+python3.13 -m build --wheel
 
 # Get the wheel file name
 WHEEL_FILE=$(ls dist/*.whl)
@@ -134,11 +134,11 @@ Source1:        requirements.txt
 Source2:        $WHEEL_FILENAME
 
 BuildArch:      x86_64
-BuildRequires:  python3-devel python3-virtualenv gcc openldap-devel git
+BuildRequires:  python3.13-devel python3.13-virtualenv gcc openldap-devel git
 
 # Runtime dependencies
 Requires:       git
-Requires:       python3
+Requires:       python3.13
 Requires:       postgresql
 Requires:       postgresql-devel
 Requires:       openldap
@@ -162,7 +162,7 @@ AutoReqProv:    no
 {
             project.get(
                 "description",
-                "Automate open source license complianceand ensure supply chain integrity",
+                "Automate open source license compliance and ensure supply chain integrity",
             )
         }
 
@@ -180,7 +180,7 @@ mkdir -p %{{buildroot}}/opt/%{{name}}/src
 
 # Create virtual environment in a temporary location first
 mkdir -p /tmp/venv_build
-python3 -m venv /tmp/venv_build --copies
+python3.13 -m venv /tmp/venv_build --copies
 
 cd %{{_sourcedir}}
 /tmp/venv_build/bin/python -m pip install --upgrade pip


### PR DESCRIPTION
Fixed [#340](https://github.com/aboutcode-org/dejacode/issues/340)

Create a script to use Docker container to build a Fedora package.

Once the .rpm is generated, one can install the package by
```
sudo dnf install /path/to/<dejacode>.rpm
```

Once it's installed, one can run the binary directly
```
dejacode
```

I need the following to run the test after installed the debian package

Create and configure a PostgreSQL user named dejacode
---------------------------------------------------------------
```
psql -h localhost -U postgres -c "CREATE USER dejacode; ALTER USER dejacode CREATEDB; GRANT ALL PRIVILEGES ON DATABASE dejacode TO dejacode;" 2>/dev/null || psql -h localhost -U postgres -c "ALTER USER dejacode CREATEDB; GRANT ALL PRIVILEGES ON DATABASE dejacode TO dejacode;"
```

Sets up environment variables and runs a test
---------------------------------------------------
```
PGPASSWORD="password" SECRET_KEY=secret dejacode test
```

- Replace the "password" with the PostgreSQL password

Output
--------
```
thomas@DESKTOP-6IMEJ77:~$ cat /etc/os-release
NAME="Fedora Linux"
VERSION="42 (WSL)"
RELEASE_TYPE=stable
ID=fedora
VERSION_ID=42
VERSION_CODENAME=""
PLATFORM_ID="platform:f42"
PRETTY_NAME="Fedora Linux 42 (WSL)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:42"
DEFAULT_HOSTNAME="fedora"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f42/system-administrators-guide/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=42
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=42
SUPPORT_END=2026-05-13
VARIANT="WSL"
VARIANT_ID=wsl
thomas@DESKTOP-6IMEJ77:~$ dejacode

Type 'dejacode help <subcommand>' for help on a specific subcommand.

Available subcommands:

[django]
    check
    compilemessages
    createcachetable
    dbshell
    diffsettings
    dumpdata
    flush
    inspectdb
    loaddata
    makemessages
    makemigrations
    migrate
    optimizemigration
    runserver
    sendtestemail
    shell
    showmigrations
    sqlflush
    sqlmigrate
    sqlsequencereset
    squashmigrations
    startapp
    startproject
    test
    testserver
Note that only Django core commands are listed as settings are not properly configured (error: Set the SECRET_KEY environment variable).
thomas@DESKTOP-6IMEJ77:~$
```

Signed-off-by: Chin Yeung Li <tli@nexb.com>