### PR TITLE
Packaging for Debian

### DIFF
--- a/etc/scripts/build_deb_docker.py
+++ b/etc/scripts/build_deb_docker.py
@@ -3,24 +3,35 @@
 Use Docker container to build a Debian package.
 Using Docker approach to ensure a consistent and isolated build environment.
 
-Requirement: The `toml` Python package
+Requirement:
+ - toml
+ - Docker
+
+To install the required Python packages, run:
 
     pip install toml
+
+To install Docker, follow the instructions at:
+    https://docs.docker.com/get-docker/
 
 To run the script:
 
     python build_deb_docker.py
 
-This script will generate the Debian package files and place them in the
-dist/debian/ directory.
+This script will generate the Debian package files and the python wheel and
+place them in the dist/debian/ directory.
 
-Once the debian package is generated, you can install it using:
+Once the debian package is generated, one can install it using:
 
     sudo apt install ./<package>.deb
 
 Note: The ./ is important - it tells apt to install from a local file
 rather than searching repositories.
 Replace the above path with the actual path to the generated debian file.
+
+Run the binary directly
+
+    dejacode
 """
 
 import os
@@ -44,6 +55,15 @@ def build_deb_with_docker():
     # Debian version conventions replace hyphens with tildes
     deb_version = project["version"].replace("-dev", "~dev")
 
+    # Get all dependencies
+    dependencies = project.get("dependencies", [])
+
+    filtered_dependencies = [
+        dep
+        for dep in dependencies
+        if "django-rest-hooks" not in dep and "django_notifications_patched" not in dep
+    ]
+
     docker_cmd = [
         "docker",
         "run",
@@ -52,38 +72,86 @@ def build_deb_with_docker():
         f"{os.getcwd()}:/workspace",
         "-w",
         "/workspace",
-        "ubuntu:22.04",
+        "ubuntu:24.04",
         "/bin/bash",
         "-c",
         f"""set -ex
             # Install build dependencies
             apt-get update
-            apt-get install -y python3-dev python3-pip python3-venv debhelper dh-python devscripts
+            apt-get install -y debhelper dh-python devscripts build-essential \
+                libsasl2-dev libldap2-dev libssl-dev libpq-dev
+
+            # Install Python 3.13 from deadsnakes PPA
+            apt-get install -y software-properties-common
+            add-apt-repository -y ppa:deadsnakes/ppa
+            apt-get update
+            apt-get install -y python3.13 python3.13-dev python3.13-venv
+
+            # Create and activate virtual environment with Python 3.13 using --copies
+            python3.13 -m venv /opt/{deb_name} --copies
+            . /opt/{deb_name}/bin/activate
+
+            # Upgrade pip to latest version and ensure setuptools is available
+            pip install --upgrade pip setuptools wheel
+
+            # Clean previous build artifacts
+            rm -rf build/
+
+            # Install non-PyPI dependencies
+            pip install https://github.com/aboutcode-org/django-rest-hooks/releases/download/1.6.1/django_rest_hooks-1.6.1-py2.py3-none-any.whl
+            pip install https://github.com/dejacode/django-notifications-patched/archive/refs/tags/2.0.0.tar.gz
+
+            # Install dependencies directly
+            {" && ".join([f'pip install "{dep}"' for dep in filtered_dependencies])}
 
             # Install build tool
             pip install build
 
             # Build the wheel
-            python3 -m build --wheel
+            python3.13 -m build --wheel
 
-            # Move wheel to dist/debian/
-            mkdir -p dist/debian
-            mv dist/*.whl dist/debian/
+            # Install the package and all remaining dependencies
+            WHEEL_FILE=$(ls dist/*.whl)
 
-            # Get the wheel file name
-            WHEEL_FILE=$(ls dist/debian/*.whl)
-            if [ -z "$WHEEL_FILE" ]; then
-                echo "Error: No wheel file found in dist/debian/." >&2
-                exit 1
-            fi
+            # Install the main package
+            pip install "$WHEEL_FILE"
+
+            # Copy source code to /opt/{deb_name}/src
+            mkdir -p /opt/{deb_name}/src
+            cp -r /workspace/* /opt/{deb_name}/src/ 2>/dev/null || true
+            rm -rf /opt/{deb_name}/src/dist /opt/{deb_name}/src/build 2>/dev/null || true
+
+            # Fix shebangs in the virtual environment to use absolute paths
+            for script in /opt/{deb_name}/bin/*; do
+                if [ -f "$script" ] && head -1 "$script" | grep -q "^#!"; then
+                    # Use sed to safely replace only the first line with absolute path
+                    sed -i '1s|.*|#!/opt/{deb_name}/bin/python3|' "$script"
+                fi
+            done
+
+            # Remove pip and wheel to reduce package size
+            rm -f /opt/{deb_name}/bin/pip* /opt/{deb_name}/bin/wheel
+
+            # Ensure all scripts are executable
+            chmod -R 755 /opt/{deb_name}/bin/
+
+            # Create wrapper script (like in RPM) instead of direct symlink
+            cat > /opt/{deb_name}/bin/dejacode-wrapper << 'WRAPPER_EOF'
+#!/bin/bash
+export PYTHONPATH="/opt/{deb_name}/src:/opt/{deb_name}/lib/python3.13/site-packages"
+cd "/opt/{deb_name}/src"
+exec "/opt/{deb_name}/bin/dejacode" "$@"
+WRAPPER_EOF
+            chmod 755 /opt/{deb_name}/bin/dejacode-wrapper
 
             # Create temporary directory for package building
             TEMP_DIR=$(mktemp -d)
             PKG_DIR="$TEMP_DIR/{deb_name}-{deb_version}"
             mkdir -p "$PKG_DIR"
 
-            # Extract wheel contents to package directory
-            unzip "$WHEEL_FILE" -d "$PKG_DIR"
+            # Copy the installed package files
+            mkdir -p "$PKG_DIR/opt/"
+            cp -r /opt/{deb_name} "$PKG_DIR/opt/"
 
             # Create DEBIAN control file
             mkdir -p "$PKG_DIR/DEBIAN"
@@ -98,14 +166,39 @@ Description: {
                 "Automate open source license compliance andensure supply chain integrity",
             )
         }
-Depends: python3
+Depends: python3.13, git, libldap2 | libldap-2.5-0, libsasl2-2, libssl3 | libssl3t64, libpq5
 Section: python
 Priority: optional
 Homepage: {project.get("urls", "").get("Homepage", "https://github.com/aboutcode-org/dejacode")}
 EOF
 
+            # Create postinst script to setup symlinks
+            cat > "$PKG_DIR/DEBIAN/postinst" << 'POSTINST'
+#!/bin/bash
+# Create symlinks for binaries - use the wrapper script
+if [ -f "/opt/{deb_name}/bin/dejacode-wrapper" ]; then
+    ln -sf "/opt/{deb_name}/bin/dejacode-wrapper" "/usr/local/bin/dejacode"
+fi
+
+# Ensure proper permissions
+chmod -R 755 /opt/{deb_name}/bin/
+POSTINST
+            chmod 755 "$PKG_DIR/DEBIAN/postinst"
+
+            # Create prerm script to clean up symlinks
+            cat > "$PKG_DIR/DEBIAN/prerm" << 'PRERM'
+#!/bin/bash
+# Remove symlinks
+rm -f "/usr/local/bin/dejacode"
+PRERM
+            chmod 755 "$PKG_DIR/DEBIAN/prerm"
+
             # Build the .deb package
-            dpkg-deb --build "$PKG_DIR" dist/debian/
+            mkdir -p dist/debian
+            dpkg-deb --build "$PKG_DIR" "dist/debian/{deb_name}_{deb_version}_all.deb"
+
+            # Move wheel to dist/debian/
+            mv dist/*.whl dist/debian/
 
             # Clean up
             rm -rf "$TEMP_DIR"


### PR DESCRIPTION
Fixed [#341](https://github.com/aboutcode-org/dejacode/issues/341)

Create a script to use Docker container to build a Debian package.

Once the .deb is generated, one can install the package by
```
sudo apt install ./<package>.deb
```
Note: The ./ is important - it tells apt to install from a local file
rather than searching repositories.

Once it's installed, one can run the binary directly
```
dejacode
```

I need the following to run the test after installed the debian package

Create and configure a PostgreSQL user named dejacode
---------------------------------------------------------------
```
psql -h localhost -U postgres -c "CREATE USER dejacode; ALTER USER dejacode CREATEDB; GRANT ALL PRIVILEGES ON DATABASE dejacode TO dejacode;" 2>/dev/null || psql -h localhost -U postgres -c "ALTER USER dejacode CREATEDB; GRANT ALL PRIVILEGES ON DATABASE dejacode TO dejacode;"
```

Assuming the system has postgresql, if not, install it with
```
sudo apt install postgresql-client
```

Sets up environment variables and runs a test
---------------------------------------------------
```
PGPASSWORD="password" SECRET_KEY=secret dejacode test
```

- Replace the "password" with the PostgreSQL password

Output
--------
```
thomas@DESKTOP-6IMEJ77:~$ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
NAME="Debian GNU/Linux"
VERSION_ID="13"
VERSION="13 (trixie)"
VERSION_CODENAME=trixie
DEBIAN_VERSION_FULL=13.0
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
thomas@DESKTOP-6IMEJ77:~$ dejacode

Type 'dejacode help <subcommand>' for help on a specific subcommand.

Available subcommands:

[django]
    check
    compilemessages
    createcachetable
    dbshell
    diffsettings
    dumpdata
    flush
    inspectdb
    loaddata
    makemessages
    makemigrations
    migrate
    optimizemigration
    runserver
    sendtestemail
    shell
    showmigrations
    sqlflush
    sqlmigrate
    sqlsequencereset
    squashmigrations
    startapp
    startproject
    test
    testserver
Note that only Django core commands are listed as settings are not properly configured (error: Set the SECRET_KEY environment variable).
thomas@DESKTOP-6IMEJ77:~$
```

Signed-off-by: Chin Yeung Li <tli@nexb.com>