### PR TITLE
Prioritize hashes and download URL for PurlDB mapping

### DIFF
--- a/component_catalog/models.py
+++ b/component_catalog/models.py
@@ -2534,10 +2534,10 @@ class Package(
         """
         Return the PurlDB entries that correspond to this Package instance.
 
-        Matching on the following fields order:
-        - Hash
-        - Download URL
-        - Package URL
+        Matching is performed in order of decreasing accuracy:
+        1. Hash - Most accurate, matches exact file content
+        2. Download URL - High accuracy, matches specific package source
+        3. Package URL - Broadest match, may return multiple versions/variants
 
         A `max_request_call` integer can be provided to limit the number of
         HTTP requests made to the PackageURL server.


### PR DESCRIPTION
In order to get an accurate mapping for a package in DejaCode to PurlDB entries the patched query prioritizes the hashes. This is needed in cases where the same PURL (without query parameters) can have multiple different download URLs as is the case with Python packages and various binaries for different hardware architectures or interpreter versions. Additionally, lookups for SHA-256 and MD5 are added as SHA-1 may not be populated under all circumstances. Hashes from SBOM imports, generated by tools such as cdxgen, commonly do not use SHA-1 anymore, since it is a mostly deprecated hashing algorithm due to the risk of hash collisions. SHA-512 could not yet be added as PurlDB does not support a lookup for it. The reason for the order of prioritization is that hashes give the most accurate for the content of the package, download URL at least points to the download location which would still allow to differentiate between the different target architectures, and lastly the PURL itself in case no fully accurate matches could be found otherwise. The results are then filtered by checking that PURLs match. Here a modification is made to also strip the query parameters from the PurlDB PURL as they may also contain them and previously caused matches to not be found. For reference see the following issues: 
- https://github.com/aboutcode-org/dejacode/issues/307 
- https://github.com/aboutcode-org/dejacode/issues/383

Checks for existing packages are also extended to compare against the other hash types.