### PR TITLE
Fix PURL comparison in get_purldb_entries

### DIFF
--- a/component_catalog/models.py
+++ b/component_catalog/models.py
@@ -75,9 +75,9 @@ from dje.models import ParentChildModelMixin
 from dje.models import ParentChildRelationshipModel
 from dje.models import ReferenceNotesMixin
 from dje.tasks import logger as tasks_logger
-from dje.utils import get_plain_purl
 from dje.utils import is_purl_str
 from dje.utils import merge_common_non_empty_values
+from dje.utils import plain_purls_equal
 from dje.utils import set_fields_from_object
 from dje.validators import generic_uri_validator
 from dje.validators import validate_url_segment
@@ -2618,13 +2618,13 @@ class Package(
             return []
 
         # Cleanup the PurlDB entries:
-        # Packages with different "plain" PURL are excluded. The qualifiers and
-        # subpaths are not involved in this comparison.
+        # Packages with different "plain" PURL are excluded.
+        # The qualifiers and subpaths are not involved in this comparison.
         if package_url:
             purldb_entries = [
                 entry
                 for entry in purldb_entries
-                if get_plain_purl(entry.get("purl", "")) == package_url
+                if plain_purls_equal(entry.get("purl"), package_url)
             ]
 
         return purldb_entries

--- a/component_catalog/tests/test_models.py
+++ b/component_catalog/tests/test_models.py
@@ -2622,10 +2622,25 @@ class ComponentCatalogModelsTestCase(TestCase):
 
         mock_find_packages.return_value = None
         purldb_entries = package1.get_purldb_entries(user=self.user)
+        self.assertEqual([], purldb_entries)
 
         mock_find_packages.return_value = [purldb_entry1, purldb_entry2, purldb_entry3]
         purldb_entries = package1.get_purldb_entries(user=self.user)
         # The purldb_entry2 is excluded as the PURL differs
+        self.assertEqual([purldb_entry1, purldb_entry2], purldb_entries)
+
+    @mock.patch("dejacode_toolkit.purldb.PurlDB.find_packages")
+    def test_package_model_get_purldb_entries_plain_purls_equal(self, mock_find_packages):
+        purl1 = "pkg:maven/core/jackson-core@2.18.3?type=jar"
+        purl2 = "pkg:maven/core/jackson-core@2.18.3?classifier=sources&type=jar"
+
+        package1_purl = "pkg:maven/core/jackson-core@2.18.3?some=qualifier"
+        package1 = make_package(self.dataspace, package_url=package1_purl)
+        purldb_entry1 = {"purl": purl1}
+        purldb_entry2 = {"purl": purl2}
+
+        mock_find_packages.return_value = [purldb_entry1, purldb_entry2]
+        purldb_entries = package1.get_purldb_entries(user=self.user)
         self.assertEqual([purldb_entry1, purldb_entry2], purldb_entries)
 
     @mock.patch("component_catalog.models.Package.get_purldb_entries")

--- a/dje/tests/test_utils.py
+++ b/dje/tests/test_utils.py
@@ -42,6 +42,7 @@ from dje.utils import localized_datetime
 from dje.utils import merge_common_non_empty_values
 from dje.utils import merge_relations
 from dje.utils import normalize_newlines_as_CR_plus_LF
+from dje.utils import plain_purls_equal
 from dje.utils import remove_field_from_query_dict
 from dje.utils import str_to_id_list
 from dje.views import get_previous_next
@@ -528,6 +529,7 @@ class DJEUtilsTestCase(TestCase):
             self.assertFalse(is_purl_fragment(fragment), msg=fragment)
 
     def test_utils_get_plain_purl(self):
+        self.assertEqual("", get_plain_purl(None))
         self.assertEqual("", get_plain_purl(""))
         self.assertEqual("not:a/purl", get_plain_purl("not:a/purl"))
         self.assertEqual("not:a/purl", get_plain_purl("not:a/purl"))
@@ -535,6 +537,23 @@ class DJEUtilsTestCase(TestCase):
         self.assertEqual(
             "pkg:npm/is-npm@1.0.0", get_plain_purl("pkg:npm/is-npm@1.0.0?qualifier=1#frament")
         )
+
+    def test_utils_plain_purls_equal(self):
+        purl1 = "pkg:npm/is-npm@1.0.0"
+        purl2 = "pkg:npm/is-npm@1.0.0"
+        self.assertTrue(plain_purls_equal(purl1, purl2))
+
+        purl1 = "pkg:npm/is-npm@1.0.0?qual=1#subpath"
+        purl2 = "pkg:npm/is-npm@1.0.0"
+        self.assertTrue(plain_purls_equal(purl1, purl2))
+
+        purl1 = "pkg:npm/is-npm@1.0.0?qual=1"
+        purl2 = "pkg:npm/is-npm@1.0.0?qual=2"
+        self.assertTrue(plain_purls_equal(purl1, purl2))
+
+        purl1 = "pkg:npm/is-npm@1.0.0"
+        purl2 = "pkg:npm/is-npm@2.0.0"
+        self.assertFalse(plain_purls_equal(purl1, purl2))
 
     def test_utils_localized_datetime(self):
         self.assertIsNone(localized_datetime(None))

--- a/dje/utils.py
+++ b/dje/utils.py
@@ -658,7 +658,14 @@ def is_purl_fragment(string):
 
 def get_plain_purl(purl_str):
     """Remove the qualifiers and subpath from the `purl_str```."""
+    if not purl_str:
+        return ""
     return purl_str.split("?")[0]
+
+
+def plain_purls_equal(purl1, purl2):
+    """Check if two PURLs are equal, ignoring qualifiers and subpath."""
+    return get_plain_purl(purl1) == get_plain_purl(purl2)
 
 
 def remove_empty_values(input_dict):


### PR DESCRIPTION
Issue: https://github.com/aboutcode-org/dejacode/issues/383

### Changes

- Exclude qualifiers and subpath from both PURLs during for comparison in `get_purldb_entries`