### PR TITLE
 feat: [five-c] Compliance extended report set

### DIFF
--- a/dje/api.py
+++ b/dje/api.py
@@ -660,6 +660,6 @@ class CycloneDXSOMActionMixin:
 
         return outputs.get_attachment_response(
             file_content=cyclonedx_bom_json,
-            filename=outputs.get_filename(instance, extension="cdx"),
+            filename=outputs.get_filename(instance, extension="cdx.json"),
             content_type="application/json",
         )

--- a/dje/outputs.py
+++ b/dje/outputs.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 from django.http import FileResponse
 from django.http import Http404
+from django.utils import timezone
 
 import msgspec
 from cyclonedx import output as cyclonedx_output
@@ -31,6 +32,27 @@ CYCLONEDX_DEFAULT_SPEC_VERSION = "1.6"
 def safe_filename(filename):
     """Convert the provided `filename` to a safe filename."""
     return re.sub("[^A-Za-z0-9.-]+", "_", filename).lower()
+
+
+def get_filename(instance, extension):
+    filename = f"dejacode_{instance.dataspace.name}_{instance}.{extension}"
+    return safe_filename(filename)
+
+
+def get_export_filename(dataspace, report_type, extension, instance=None):
+    """Return a safe filename for exports."""
+    timestamp = timezone.now().strftime("%Y-%m-%d_%H%M%S")
+    if instance:
+        filename = f"dejacode_{dataspace.name}_{instance}_{report_type}_{timestamp}.{extension}"
+    else:
+        filename = f"dejacode_{dataspace.name}_{report_type}_{timestamp}.{extension}"
+    return safe_filename(filename)
+
+
+def get_spdx_filename(spdx_document):
+    document_name = spdx_document.as_dict()["name"]
+    filename = f"{document_name}.spdx.json"
+    return safe_filename(filename)
 
 
 def get_attachment_response(file_content, filename, content_type):
@@ -95,12 +117,6 @@ def get_spdx_document(instance, user):
     )
 
     return document
-
-
-def get_spdx_filename(spdx_document):
-    document_name = spdx_document.as_dict()["name"]
-    filename = f"{document_name}.spdx.json"
-    return safe_filename(filename)
 
 
 def get_cyclonedx_bom(instance, user, include_components=True, include_vex=False):
@@ -193,12 +209,6 @@ def sort_bom_with_schema_ordering(bom_as_dict, schema_version):
     ordered_dict = {key: bom_as_dict.get(key) for key in order_from_schema if key in bom_as_dict}
 
     return json.dumps(ordered_dict, indent=2)
-
-
-def get_filename(instance, extension):
-    base_filename = f"dejacode_{instance.dataspace.name}_{instance._meta.model_name}"
-    filename = f"{base_filename}_{instance}.{extension}.json"
-    return safe_filename(filename)
 
 
 CDX_STATE_TO_CSAF_STATUS = {

--- a/dje/tests/test_outputs.py
+++ b/dje/tests/test_outputs.py
@@ -191,9 +191,35 @@ class OutputsTestCase(TestCase):
 
     def test_outputs_get_filename(self):
         self.assertEqual(
-            "dejacode_nexb_product_product1_with_space_1.0.cdx.json",
-            outputs.get_filename(instance=self.product1, extension="cdx"),
+            "dejacode_nexb_product1_with_space_1.0.cdx.json",
+            outputs.get_filename(instance=self.product1, extension="cdx.json"),
         )
+
+    def test_outputs_get_export_filename(self):
+        mock_now = datetime(2024, 10, 10, 12, 0, 0, tzinfo=UTC)
+        with mock.patch("dje.outputs.timezone") as mock_timezone:
+            mock_timezone.now.return_value = mock_now
+
+            filename_without_instance = outputs.get_export_filename(
+                dataspace=self.dataspace,
+                report_type="vulnerabilities",
+                extension="csv",
+            )
+            self.assertEqual(
+                "dejacode_nexb_vulnerabilities_2024-10-10_120000.csv",
+                filename_without_instance,
+            )
+
+            filename_with_instance = outputs.get_export_filename(
+                dataspace=self.dataspace,
+                report_type="vulnerabilities",
+                extension="csv",
+                instance=self.product1,
+            )
+            self.assertEqual(
+                "dejacode_nexb_product1_with_space_1.0_vulnerabilities_2024-10-10_120000.csv",
+                filename_with_instance,
+            )
 
     def test_outputs_get_csaf_security_advisory(self):
         mock_now = datetime(2024, 12, 19, 12, 0, 0, tzinfo=UTC)

--- a/dje/views.py
+++ b/dje/views.py
@@ -2407,11 +2407,11 @@ class ExportCycloneDXBOMView(
         spec_version = self.request.GET.get("spec_version")
         content = self.request.GET.get("content", "sbom")
 
-        extension = "cdx"
+        extension = "cdx.json"
         include_components = True
         include_vex = False
         if content == "vex":
-            extension = "vex"
+            extension = "vex.json"
             include_components = False
             include_vex = True
         elif content == "combined":
@@ -2446,7 +2446,7 @@ class ExportCSAFDocumentView(
         product = self.get_object()
         security_advisory = outputs.get_csaf_security_advisory(product)
         security_advisory_json = security_advisory.model_dump_json(indent=2, exclude_none=True)
-        filename = outputs.get_filename(product, extension="csaf.vex")
+        filename = outputs.get_filename(product, extension="csaf.vex.json")
 
         return outputs.get_attachment_response(
             file_content=security_advisory_json,
@@ -2464,7 +2464,7 @@ class ExportOpenVEXView(
     def get(self, request, *args, **kwargs):
         product = self.get_object()
         openvex_document_json = outputs.get_openvex_document_json(product)
-        filename = outputs.get_filename(product, extension="openvex")
+        filename = outputs.get_filename(product, extension="openvex.json")
 
         return outputs.get_attachment_response(
             file_content=openvex_document_json,

--- a/product_portfolio/models.py
+++ b/product_portfolio/models.py
@@ -417,6 +417,9 @@ class Product(
     def get_export_openvex_url(self):
         return self.get_url("export_openvex")
 
+    def get_export_license_compliance_url(self):
+        return self.get_url("export_license_compliance")
+
     @property
     def cyclonedx_bom_ref(self):
         return str(self.uuid)

--- a/product_portfolio/models.py
+++ b/product_portfolio/models.py
@@ -420,6 +420,9 @@ class Product(
     def get_export_license_compliance_url(self):
         return self.get_url("export_license_compliance")
 
+    def get_export_security_compliance_url(self):
+        return self.get_url("export_security_compliance")
+
     @property
     def cyclonedx_bom_ref(self):
         return str(self.uuid)

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_panels.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_panels.html
@@ -18,6 +18,40 @@
             {% trans "Warning" %}
           </span>
         {% endif %}
+        <div class="dropdown">
+          <button class="btn btn-sm btn-link text-body-secondary p-0" data-bs-toggle="dropdown">
+            <i class="fas fa-download"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-end">
+            {% with export_license_compliance_url=product.get_export_license_compliance_url %}
+            <li>
+              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=csv">
+                <i class="fas fa-download me-1"></i>{% trans "Comma-separated Values (.csv)" %}
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=json">
+                <i class="fas fa-download me-1"></i>{% trans "JSON (.json)" %}
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=ods">
+                <i class="fas fa-download me-1"></i>{% trans "OpenDocument (.ods)" %}
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=xlsx">
+                <i class="fas fa-download me-1"></i>{% trans "Microsoft Excel (.xlsx)" %}
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=yaml">
+                <i class="fas fa-download me-1"></i>{% trans "YAML (.yaml)" %}
+              </a>
+            </li>
+            {% endwith %}
+          </ul>
+        </div>
       </div>
 
       <p class="text-secondary small mb-2">

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_panels.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_panels.html
@@ -5,52 +5,48 @@
     <div class="border rounded-3 p-3 h-100">
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h3 class="fs-6 fw-medium mb-0">{% trans "License compliance" %}</h3>
-        {% if license_issues_count == 0 %}
-          <span class="badge text-bg-success">
-            {% trans "OK" %}
-          </span>
-        {% elif license_error_count > 0 %}
-          <span class="badge text-bg-danger">
-            {% trans "Error" %}
-          </span>
-        {% else %}
-          <span class="badge text-bg-warning">
-            {% trans "Warning" %}
-          </span>
-        {% endif %}
-        <div class="dropdown">
-          <button class="btn btn-sm btn-link text-body-secondary p-0" data-bs-toggle="dropdown">
-            <i class="fas fa-download"></i>
-          </button>
-          <ul class="dropdown-menu dropdown-menu-end">
-            {% with export_license_compliance_url=product.get_export_license_compliance_url %}
-            <li>
-              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=csv">
-                <i class="fas fa-download me-1"></i>{% trans "Comma-separated Values (.csv)" %}
-              </a>
-            </li>
-            <li>
-              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=json">
-                <i class="fas fa-download me-1"></i>{% trans "JSON (.json)" %}
-              </a>
-            </li>
-            <li>
-              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=ods">
-                <i class="fas fa-download me-1"></i>{% trans "OpenDocument (.ods)" %}
-              </a>
-            </li>
-            <li>
-              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=xlsx">
-                <i class="fas fa-download me-1"></i>{% trans "Microsoft Excel (.xlsx)" %}
-              </a>
-            </li>
-            <li>
-              <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=yaml">
-                <i class="fas fa-download me-1"></i>{% trans "YAML (.yaml)" %}
-              </a>
-            </li>
-            {% endwith %}
-          </ul>
+        <div class="d-flex align-items-center gap-2 ms-auto">
+          <div class="dropdown">
+            <button class="btn btn-sm btn-link text-body-secondary p-0" data-bs-toggle="dropdown">
+              <i class="fas fa-download"></i>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              {% with export_license_compliance_url=product.get_export_license_compliance_url %}
+              <li>
+                <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=csv">
+                  <i class="fas fa-download me-1"></i>{% trans "Comma-separated Values (.csv)" %}
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=json">
+                  <i class="fas fa-download me-1"></i>{% trans "JSON (.json)" %}
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=ods">
+                  <i class="fas fa-download me-1"></i>{% trans "OpenDocument (.ods)" %}
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=xlsx">
+                  <i class="fas fa-download me-1"></i>{% trans "Microsoft Excel (.xlsx)" %}
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ export_license_compliance_url }}?export=yaml">
+                  <i class="fas fa-download me-1"></i>{% trans "YAML (.yaml)" %}
+                </a>
+              </li>
+              {% endwith %}
+            </ul>
+          </div>
+          {% if license_issues_count == 0 %}
+            <span class="badge text-bg-success">{% trans "OK" %}</span>
+          {% elif license_error_count > 0 %}
+            <span class="badge text-bg-danger">{% trans "Error" %}</span>
+          {% else %}
+            <span class="badge text-bg-warning">{% trans "Warning" %}</span>
+          {% endif %}
         </div>
       </div>
 

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_panels.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_panels.html
@@ -103,17 +103,53 @@
       {# Header #}
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h3 class="fs-6 fw-medium mb-0">{% trans "Security compliance" %}</h3>
-        {% if vulnerability_count == 0 or above_threshold_count == 0 %}
-          <span class="badge text-bg-success">{% trans "OK" %}</span>
-        {% elif max_vulnerability_severity == "critical" %}
-          <span class="badge text-bg-danger">{% trans "Critical" %}</span>
-        {% elif max_vulnerability_severity == "high" %}
-          <span class="badge bg-warning-orange">{% trans "High" %}</span>
-        {% elif max_vulnerability_severity == "medium" %}
-          <span class="badge text-bg-warning">{% trans "Medium" %}</span>
-        {% else %}
-          <span class="badge text-bg-info">{% trans "Low" %}</span>
-        {% endif %}
+        <div class="d-flex align-items-center gap-2 ms-auto">
+          <div class="dropdown">
+            <button class="btn btn-sm btn-link text-body-secondary p-0" data-bs-toggle="dropdown">
+              <i class="fas fa-download"></i>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              {% with export_security_compliance_url=product.get_export_security_compliance_url %}
+              <li>
+                <a class="dropdown-item" href="{{ export_security_compliance_url }}?export=csv">
+                  <i class="fas fa-download me-1"></i>{% trans "Comma-separated Values (.csv)" %}
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ export_security_compliance_url }}?export=json">
+                  <i class="fas fa-download me-1"></i>{% trans "JSON (.json)" %}
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ export_security_compliance_url }}?export=ods">
+                  <i class="fas fa-download me-1"></i>{% trans "OpenDocument (.ods)" %}
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ export_security_compliance_url }}?export=xlsx">
+                  <i class="fas fa-download me-1"></i>{% trans "Microsoft Excel (.xlsx)" %}
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{{ export_security_compliance_url }}?export=yaml">
+                  <i class="fas fa-download me-1"></i>{% trans "YAML (.yaml)" %}
+                </a>
+              </li>
+              {% endwith %}
+            </ul>
+          </div>
+          {% if vulnerability_count == 0 or above_threshold_count == 0 %}
+            <span class="badge text-bg-success">{% trans "OK" %}</span>
+          {% elif max_vulnerability_severity == "critical" %}
+            <span class="badge text-bg-danger">{% trans "Critical" %}</span>
+          {% elif max_vulnerability_severity == "high" %}
+            <span class="badge bg-warning-orange">{% trans "High" %}</span>
+          {% elif max_vulnerability_severity == "medium" %}
+            <span class="badge text-bg-warning">{% trans "Medium" %}</span>
+          {% else %}
+            <span class="badge text-bg-info">{% trans "Low" %}</span>
+          {% endif %}
+        </div>
       </div>
 
       {# Summary #}

--- a/product_portfolio/tests/test_api.py
+++ b/product_portfolio/tests/test_api.py
@@ -573,7 +573,7 @@ class ProductAPITestCase(MaxQueryMixin, TestCase):
 
         response = self.client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        expected = 'attachment; filename="dejacode_nexb_product_p1.cdx.json"'
+        expected = 'attachment; filename="dejacode_nexb_p1.cdx.json"'
         self.assertEqual(expected, response["Content-Disposition"])
         self.assertEqual("application/json", response["Content-Type"])
         self.assertIn('"specVersion": "1.6"', str(response.getvalue()))

--- a/product_portfolio/tests/test_views.py
+++ b/product_portfolio/tests/test_views.py
@@ -3060,9 +3060,7 @@ class ProductPortfolioViewsTestCase(MaxQueryMixin, TestCase):
         self.client.login(username=self.super_user.username, password="secret")
         export_cyclonedx_url = self.product1.get_export_cyclonedx_url()
         response = self.client.get(export_cyclonedx_url)
-        self.assertEqual(
-            "dejacode_nexb_product_product1_with_space_1.0.cdx.json", response.filename
-        )
+        self.assertEqual("dejacode_nexb_product1_with_space_1.0.cdx.json", response.filename)
         self.assertEqual("application/json", response.headers["Content-Type"])
 
         content = io.BytesIO(b"".join(response.streaming_content))
@@ -3145,9 +3143,7 @@ class ProductPortfolioViewsTestCase(MaxQueryMixin, TestCase):
         self.client.login(username=self.super_user.username, password="secret")
         export_openvex_url = self.product1.get_export_openvex_url()
         response = self.client.get(export_openvex_url)
-        self.assertEqual(
-            "dejacode_nexb_product_product1_with_space_1.0.openvex.json", response.filename
-        )
+        self.assertEqual("dejacode_nexb_product1_with_space_1.0.openvex.json", response.filename)
         self.assertEqual("application/json", response.headers["Content-Type"])
 
         content = io.BytesIO(b"".join(response.streaming_content))

--- a/product_portfolio/tests/test_views.py
+++ b/product_portfolio/tests/test_views.py
@@ -38,8 +38,10 @@ from dje.tests import add_perms
 from dje.tests import create_superuser
 from dje.tests import create_user
 from license_library.models import License
+from license_library.tests import make_license
 from organization.models import Owner
 from policy.models import UsagePolicy
+from policy.tests import make_usage_policy
 from product_portfolio.forms import ProductForm
 from product_portfolio.forms import ProductGridConfigurationForm
 from product_portfolio.forms import ProductPackageForm
@@ -3993,3 +3995,118 @@ class ProductPortfolioViewsTestCase(MaxQueryMixin, TestCase):
         self.assertEqual(1, product_data["vulnerability_count"])
         self.assertEqual(1, product_data["critical_count"])
         self.assertEqual(0, product_data["low_count"])
+
+    def test_product_portfolio_product_license_compliance_export_view_csv(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_license_compliance_url()
+
+        usage_policy = make_usage_policy(
+            self.dataspace,
+            model=License,
+            compliance_alert="error",
+        )
+        license1 = make_license(
+            self.dataspace,
+            key="mit",
+            short_name="MIT",
+            spdx_license_key="MIT",
+            usage_policy=usage_policy,
+        )
+        make_product_package(self.product1, license_expression=license1.key)
+
+        response = self.client.get(url + "?export=csv")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("text/csv", response["Content-Type"])
+        self.assertIn("license_compliance_", response["Content-Disposition"])
+        self.assertIn(".csv", response["Content-Disposition"])
+        # Filename includes the product since the view carries a detail object
+        self.assertIn("product1_with_space", response["Content-Disposition"])
+
+        content = response.content.decode()
+        self.assertIn("SPDX license key,Short name,Key,Packages,Compliance alert", content)
+        self.assertIn("MIT,MIT,mit,1,error", content)
+
+    def test_product_portfolio_product_license_compliance_export_view_json(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_license_compliance_url()
+
+        license1 = make_license(self.dataspace, key="mit", short_name="MIT")
+        license2 = make_license(self.dataspace, key="apache-2.0", short_name="Apache 2.0")
+        make_product_package(self.product1, license_expression=license1.key)
+        make_product_package(self.product1, license_expression=f"{license1.key} AND {license2.key}")
+
+        response = self.client.get(url + "?export=json")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("application/json", response["Content-Type"])
+        self.assertIn("license_compliance_", response["Content-Disposition"])
+
+        data = json.loads(response.content)
+        self.assertEqual(2, len(data))
+        # Ordered by package_count desc: MIT (2 packages) before Apache (1 package)
+        self.assertEqual("mit", data[0]["key"])
+        self.assertEqual(2, data[0]["package_count"])
+        self.assertEqual("apache-2.0", data[1]["key"])
+        self.assertEqual(1, data[1]["package_count"])
+
+    def test_product_portfolio_product_license_compliance_export_view_xlsx(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_license_compliance_url()
+
+        license1 = make_license(self.dataspace, key="mit", short_name="MIT")
+        make_product_package(self.product1, license_expression=license1.key)
+        response = self.client.get(url + "?export=xlsx")
+
+        self.assertEqual(200, response.status_code)
+        expected_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        self.assertEqual(expected_type, response["Content-Type"])
+        self.assertIn("license_compliance_", response["Content-Disposition"])
+        self.assertIn(".xlsx", response["Content-Disposition"])
+
+    def test_product_portfolio_product_license_compliance_export_view_ods(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_license_compliance_url()
+
+        license1 = make_license(self.dataspace, key="mit", short_name="MIT")
+        make_product_package(self.product1, license_expression=license1.key)
+
+        response = self.client.get(url + "?export=ods")
+        self.assertEqual(200, response.status_code)
+        expected_type = "application/vnd.oasis.opendocument.spreadsheet"
+        self.assertEqual(expected_type, response["Content-Type"])
+        self.assertIn("license_compliance_", response["Content-Disposition"])
+        self.assertIn(".ods", response["Content-Disposition"])
+
+    def test_product_portfolio_product_license_compliance_export_view_yaml(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_license_compliance_url()
+
+        license1 = make_license(self.dataspace, key="mit", short_name="MIT")
+        make_product_package(self.product1, license_expression=license1.key)
+
+        response = self.client.get(url + "?export=yaml")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("application/x-yaml", response["Content-Type"])
+        self.assertIn("license_compliance_", response["Content-Disposition"])
+        self.assertIn(".yaml", response["Content-Disposition"])
+
+        content = response.content.decode()
+        self.assertIn("mit", content)
+        self.assertIn("package_count", content)
+
+    def test_product_portfolio_product_license_compliance_export_view_respects_permissions(self):
+        self.client.login(username=self.basic_user.username, password="secret")
+        url = self.product1.get_export_license_compliance_url()
+
+        license1 = make_license(self.dataspace, key="mit", short_name="MIT")
+        make_product_package(self.product1, license_expression=license1.key)
+
+        # Without permission, the detail lookup should 404
+        response = self.client.get(url + "?export=json")
+        self.assertEqual(404, response.status_code)
+
+        # With permission, the export is returned
+        assign_perm("view_product", self.basic_user, self.product1)
+        response = self.client.get(url + "?export=json")
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.content)
+        self.assertEqual("mit", data[0]["key"])

--- a/product_portfolio/tests/test_views.py
+++ b/product_portfolio/tests/test_views.py
@@ -4110,3 +4110,142 @@ class ProductPortfolioViewsTestCase(MaxQueryMixin, TestCase):
         self.assertEqual(200, response.status_code)
         data = json.loads(response.content)
         self.assertEqual("mit", data[0]["key"])
+
+    def test_product_portfolio_product_security_compliance_export_view_csv(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_security_compliance_url()
+
+        package = make_package(self.dataspace, filename="isolated")
+        vulnerability = make_vulnerability(
+            self.dataspace,
+            affecting=package,
+            aliases=["CVE-2024-42005", "GHSA-pv4p-cwwg-4rph", "PYSEC-2024-70"],
+        )
+        make_product_package(self.product1, package=package)
+
+        response = self.client.get(url + "?export=csv")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("text/csv", response["Content-Type"])
+        self.assertIn("security_compliance_", response["Content-Disposition"])
+        self.assertIn(".csv", response["Content-Disposition"])
+        self.assertIn("product1_with_space", response["Content-Disposition"])
+
+        content = response.content.decode()
+        expected_header = (
+            "Vulnerability ID,Aliases,Summary,Risk level,Risk score,"
+            "Exploitability,Weighted severity,Affected packages,Fixed packages,"
+            "Reference URL"
+        )
+        self.assertIn(expected_header, content)
+        self.assertIn(vulnerability.vulnerability_id, content)
+        # Aliases must be flattened to a comma-joined string, not a Python list repr.
+        self.assertIn('"CVE-2024-42005, GHSA-pv4p-cwwg-4rph, PYSEC-2024-70"', content)
+        self.assertNotIn("['CVE-2024-42005'", content)
+
+    def test_product_portfolio_product_security_compliance_export_view_json(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_security_compliance_url()
+
+        package = make_package(self.dataspace, filename="isolated")
+        vulnerability = make_vulnerability(
+            self.dataspace,
+            affecting=package,
+            aliases=["CVE-2024-42005", "GHSA-pv4p-cwwg-4rph", "PYSEC-2024-70"],
+        )
+        make_product_package(self.product1, package=package)
+
+        response = self.client.get(url + "?export=json")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("application/json", response["Content-Type"])
+        self.assertIn("security_compliance_", response["Content-Disposition"])
+
+        data = json.loads(response.content)
+        self.assertEqual(1, len(data))
+        self.assertEqual(vulnerability.vulnerability_id, data[0]["vulnerability_id"])
+        # Aliases stay a real list in JSON, not a comma-joined string.
+        self.assertEqual(
+            ["CVE-2024-42005", "GHSA-pv4p-cwwg-4rph", "PYSEC-2024-70"],
+            data[0]["aliases"],
+        )
+        self.assertEqual(1, data[0]["affected_package_count"])
+
+    def test_product_portfolio_product_security_compliance_export_view_xlsx(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_security_compliance_url()
+
+        make_vulnerability(
+            self.dataspace,
+            affecting=self.package1,
+            aliases=["CVE-2024-42005", "GHSA-pv4p-cwwg-4rph", "PYSEC-2024-70"],
+        )
+        make_product_package(self.product1, package=self.package1)
+
+        response = self.client.get(url + "?export=xlsx")
+        self.assertEqual(200, response.status_code)
+        expected_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        self.assertEqual(expected_type, response["Content-Type"])
+        self.assertIn("security_compliance_", response["Content-Disposition"])
+        self.assertIn(".xlsx", response["Content-Disposition"])
+
+    def test_product_portfolio_product_security_compliance_export_view_ods(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_security_compliance_url()
+
+        make_vulnerability(
+            self.dataspace,
+            affecting=self.package1,
+            aliases=["CVE-2024-42005", "GHSA-pv4p-cwwg-4rph", "PYSEC-2024-70"],
+        )
+        make_product_package(self.product1, package=self.package1)
+
+        response = self.client.get(url + "?export=ods")
+        self.assertEqual(200, response.status_code)
+        expected_type = "application/vnd.oasis.opendocument.spreadsheet"
+        self.assertEqual(expected_type, response["Content-Type"])
+        self.assertIn("security_compliance_", response["Content-Disposition"])
+        self.assertIn(".ods", response["Content-Disposition"])
+
+    def test_product_portfolio_product_security_compliance_export_view_yaml(self):
+        self.client.login(username=self.super_user.username, password="secret")
+        url = self.product1.get_export_security_compliance_url()
+
+        vulnerability = make_vulnerability(
+            self.dataspace,
+            affecting=self.package1,
+            aliases=["CVE-2024-42005", "GHSA-pv4p-cwwg-4rph", "PYSEC-2024-70"],
+        )
+        make_product_package(self.product1, package=self.package1)
+
+        response = self.client.get(url + "?export=yaml")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("application/x-yaml", response["Content-Type"])
+        self.assertIn("security_compliance_", response["Content-Disposition"])
+        self.assertIn(".yaml", response["Content-Disposition"])
+
+        content = response.content.decode()
+        self.assertIn(vulnerability.vulnerability_id, content)
+        self.assertIn("vulnerability_id", content)
+
+    def test_product_portfolio_product_security_compliance_export_view_respects_permissions(self):
+        self.client.login(username=self.basic_user.username, password="secret")
+        url = self.product1.get_export_security_compliance_url()
+
+        package = make_package(self.dataspace, filename="isolated")
+        vulnerability = make_vulnerability(
+            self.dataspace,
+            affecting=package,
+            aliases=["CVE-2024-42005", "GHSA-pv4p-cwwg-4rph", "PYSEC-2024-70"],
+        )
+        make_product_package(self.product1, package=package)
+
+        # Without permission, the detail lookup should 404
+        response = self.client.get(url + "?export=json")
+        self.assertEqual(404, response.status_code)
+
+        # With permission, the export is returned
+        assign_perm("view_product", self.basic_user, self.product1)
+        response = self.client.get(url + "?export=json")
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.content)
+        vulnerability_ids = [entry["vulnerability_id"] for entry in data]
+        self.assertIn(vulnerability.vulnerability_id, vulnerability_ids)

--- a/product_portfolio/urls.py
+++ b/product_portfolio/urls.py
@@ -23,6 +23,7 @@ from product_portfolio.views import ProductExportOpenVEXView
 from product_portfolio.views import ProductExportSPDXDocumentView
 from product_portfolio.views import ProductLicenseComplianceExportView
 from product_portfolio.views import ProductListView
+from product_portfolio.views import ProductSecurityComplianceExportView
 from product_portfolio.views import ProductSendAboutFilesView
 from product_portfolio.views import ProductTabCodebaseView
 from product_portfolio.views import ProductTabComplianceView
@@ -117,6 +118,7 @@ urlpatterns = [
     *product_path("export_csaf", ProductExportCSAFDocumentView.as_view()),
     *product_path("export_openvex", ProductExportOpenVEXView.as_view()),
     *product_path("export_license_compliance", ProductLicenseComplianceExportView.as_view()),
+    *product_path("export_security_compliance", ProductSecurityComplianceExportView.as_view()),
     *product_path("attribution", AttributionView.as_view()),
     *product_path("change", ProductUpdateView.as_view()),
     *product_path("delete", ProductDeleteView.as_view()),

--- a/product_portfolio/urls.py
+++ b/product_portfolio/urls.py
@@ -21,6 +21,7 @@ from product_portfolio.views import ProductExportCSAFDocumentView
 from product_portfolio.views import ProductExportCycloneDXBOMView
 from product_portfolio.views import ProductExportOpenVEXView
 from product_portfolio.views import ProductExportSPDXDocumentView
+from product_portfolio.views import ProductLicenseComplianceExportView
 from product_portfolio.views import ProductListView
 from product_portfolio.views import ProductSendAboutFilesView
 from product_portfolio.views import ProductTabCodebaseView
@@ -115,6 +116,7 @@ urlpatterns = [
     *product_path("export_cyclonedx", ProductExportCycloneDXBOMView.as_view()),
     *product_path("export_csaf", ProductExportCSAFDocumentView.as_view()),
     *product_path("export_openvex", ProductExportOpenVEXView.as_view()),
+    *product_path("export_license_compliance", ProductLicenseComplianceExportView.as_view()),
     *product_path("attribution", AttributionView.as_view()),
     *product_path("change", ProductUpdateView.as_view()),
     *product_path("delete", ProductDeleteView.as_view()),

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -2865,12 +2865,21 @@ class ExportComplianceMixin:
             return self.export_yaml()
         return self.export_json()
 
+    @staticmethod
+    def normalize_cell_value(value):
+        """Convert list values to comma-joined strings for spreadsheet cells."""
+        if isinstance(value, list):
+            return ", ".join(str(item) for item in value)
+        return value
+
     def export_csv(self):
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = self.get_content_disposition("csv")
         writer = csv.writer(response)
         writer.writerow(self.get_export_headers())
-        writer.writerows(self.get_export_rows())
+        writer.writerows(
+            [self.normalize_cell_value(value) for value in row] for row in self.get_export_rows()
+        )
         return response
 
     def export_xlsx(self):
@@ -2882,7 +2891,7 @@ class ExportComplianceMixin:
         worksheet.append(headers)
 
         for row in self.get_export_rows():
-            worksheet.append(row)
+            worksheet.append([self.normalize_cell_value(value) for value in row])
 
         style_xlsx_worksheet(worksheet, headers)
 
@@ -2909,7 +2918,9 @@ class ExportComplianceMixin:
         for row_data in [self.get_export_headers()] + list(self.get_export_rows()):
             row = odfdo.Row()
             for value in row_data:
-                row.append(odfdo.Cell(str(value if value is not None else ""), cell_type="string"))
+                normalized = self.normalize_cell_value(value)
+                cell_value = str(normalized) if normalized is not None else ""
+                row.append(odfdo.Cell(cell_value, cell_type="string"))
             table.append(row)
 
         document = odfdo.Document("spreadsheet")
@@ -3069,3 +3080,44 @@ class ProductLicenseComplianceExportView(
             package_count=Count("productpackage"),
             compliance_alert=F("usage_policy__compliance_alert"),
         ).order_by("-package_count")
+
+
+class ProductSecurityComplianceExportView(
+    LoginRequiredMixin,
+    ExportComplianceMixin,
+    BaseProductViewMixin,
+    DataspaceScopeMixin,
+    GetDataspacedObjectMixin,
+    BaseDetailView,
+):
+    """Export security compliance data for a single product."""
+
+    export_filename = "security_compliance"
+    export_fields = {
+        "vulnerability_id": "Vulnerability ID",
+        "aliases": "Aliases",
+        "summary": "Summary",
+        "risk_level": "Risk level",
+        "risk_score": "Risk score",
+        "exploitability": "Exploitability",
+        "weighted_severity": "Weighted severity",
+        "affected_package_count": "Affected packages",
+        "fixed_packages_count": "Fixed packages",
+        "resource_url": "Reference URL",
+    }
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        return super().get(request, *args, **kwargs)
+
+    def get_export_queryset(self):
+        product = self.object
+        vulnerabilities = product.get_vulnerability_qs(risk_threshold=None)
+        package_ids = product.productpackages.values_list("package_id", flat=True)
+        return vulnerabilities.annotate(
+            affected_package_count=Count(
+                "affected_packages",
+                filter=Q(affected_packages__in=package_ids),
+                distinct=True,
+            ),
+        ).order_by_risk()

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -49,7 +49,6 @@ from django.shortcuts import render
 from django.template.context_processors import csrf
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.html import format_html
 from django.utils.html import mark_safe
@@ -81,6 +80,7 @@ from dejacode_toolkit.scancodeio import get_package_download_url
 from dejacode_toolkit.scancodeio import get_scan_results_as_file_url
 from dejacode_toolkit.utils import sha1
 from dejacode_toolkit.vulnerablecode import VulnerableCode
+from dje import outputs
 from dje.client_data import add_client_data
 from dje.filters import BooleanChoiceFilter
 from dje.filters import HasCountFilter
@@ -2837,12 +2837,22 @@ class ExportComplianceMixin:
     def get_export_rows(self):
         return self.get_export_queryset().values_list(*self.get_export_fields())
 
-    def get_export_filename(self, extension):
-        timestamp = timezone.now().strftime("%Y-%m-%d_%H%M%S")
-        return f"{self.export_filename}_{timestamp}.{extension}"
+    def build_export_filename(self, extension):
+        instance = getattr(self, "object", None)
+        if instance:
+            dataspace = instance.dataspace
+        else:
+            dataspace = self.dataspace
+
+        return outputs.get_export_filename(
+            dataspace=dataspace,
+            report_type=self.export_filename,
+            extension=extension,
+            instance=instance,
+        )
 
     def get_content_disposition(self, extension):
-        return f'attachment; filename="{self.get_export_filename(extension)}"'
+        return f'attachment; filename="{self.build_export_filename(extension)}"'
 
     def export(self, export_format):
         if export_format == "csv":
@@ -3051,12 +3061,6 @@ class ProductLicenseComplianceExportView(
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
         return super().get(request, *args, **kwargs)
-
-    def get_export_filename(self, extension):
-        timestamp = timezone.now().strftime("%Y-%m-%d_%H%M%S")
-        product = self.get_object()
-        slug = f"{product.name}_{product.version}".replace(" ", "_")
-        return f"{self.export_filename}_{slug}_{timestamp}.{extension}"
 
     def get_export_queryset(self):
         productpackages = self.object.productpackages.all()

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -3048,6 +3048,10 @@ class ProductLicenseComplianceExportView(
         "compliance_alert": "Compliance alert",
     }
 
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        return super().get(request, *args, **kwargs)
+
     def get_export_filename(self, extension):
         timestamp = timezone.now().strftime("%Y-%m-%d_%H%M%S")
         product = self.get_object()
@@ -3057,35 +3061,7 @@ class ProductLicenseComplianceExportView(
     def get_export_queryset(self):
         productpackages = self.object.productpackages.all()
         licenses = License.objects.filter(productpackage__in=productpackages)
-        return (
-            licenses.values("key", "short_name", "spdx_license_key")
-            .annotate(
-                package_count=Count("productpackage"),
-                compliance_alert=F("usage_policy__compliance_alert"),
-            )
-            .order_by("-package_count")
-        )
-
-    def get_export_rows(self):
-        return [
-            tuple(entry.get(field, "") or "" for field in self.export_fields)
-            for entry in self.get_export_queryset()
-        ]
-
-    def export_json(self):
-        data = list(self.get_export_queryset())
-        response = HttpResponse(
-            json.dumps(data, indent=2, default=str),
-            content_type="application/json",
-        )
-        response["Content-Disposition"] = self.get_content_disposition("json")
-        return response
-
-    def export_yaml(self):
-        data = json.loads(json.dumps(list(self.get_export_queryset()), default=str))
-        response = HttpResponse(
-            saneyaml.dump(data),
-            content_type="application/x-yaml",
-        )
-        response["Content-Disposition"] = self.get_content_disposition("yaml")
-        return response
+        return licenses.annotate(
+            package_count=Count("productpackage"),
+            compliance_alert=F("usage_policy__compliance_alert"),
+        ).order_by("-package_count")

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -60,6 +60,7 @@ from django.views.decorators.http import require_POST
 from django.views.generic import DetailView
 from django.views.generic import FormView
 from django.views.generic import TemplateView
+from django.views.generic.detail import BaseDetailView
 
 import odfdo
 import saneyaml
@@ -3026,3 +3027,65 @@ class ComplianceDashboardView(LoginRequiredMixin, ExportComplianceMixin, Dataspa
         )
 
         return context
+
+
+class ProductLicenseComplianceExportView(
+    LoginRequiredMixin,
+    ExportComplianceMixin,
+    BaseProductViewMixin,
+    DataspaceScopeMixin,
+    GetDataspacedObjectMixin,
+    BaseDetailView,
+):
+    """Export license compliance data for a single product."""
+
+    export_filename = "license_compliance"
+    export_fields = {
+        "spdx_license_key": "SPDX license key",
+        "short_name": "Short name",
+        "key": "Key",
+        "package_count": "Packages",
+        "compliance_alert": "Compliance alert",
+    }
+
+    def get_export_filename(self, extension):
+        timestamp = timezone.now().strftime("%Y-%m-%d_%H%M%S")
+        product = self.get_object()
+        slug = f"{product.name}_{product.version}".replace(" ", "_")
+        return f"{self.export_filename}_{slug}_{timestamp}.{extension}"
+
+    def get_export_queryset(self):
+        productpackages = self.object.productpackages.all()
+        licenses = License.objects.filter(productpackage__in=productpackages)
+        return (
+            licenses.values("key", "short_name", "spdx_license_key")
+            .annotate(
+                package_count=Count("productpackage"),
+                compliance_alert=F("usage_policy__compliance_alert"),
+            )
+            .order_by("-package_count")
+        )
+
+    def get_export_rows(self):
+        return [
+            tuple(entry.get(field, "") or "" for field in self.export_fields)
+            for entry in self.get_export_queryset()
+        ]
+
+    def export_json(self):
+        data = list(self.get_export_queryset())
+        response = HttpResponse(
+            json.dumps(data, indent=2, default=str),
+            content_type="application/json",
+        )
+        response["Content-Disposition"] = self.get_content_disposition("json")
+        return response
+
+    def export_yaml(self):
+        data = json.loads(json.dumps(list(self.get_export_queryset()), default=str))
+        response = HttpResponse(
+            saneyaml.dump(data),
+            content_type="application/x-yaml",
+        )
+        response["Content-Disposition"] = self.get_content_disposition("yaml")
+        return response


### PR DESCRIPTION
## Issues

- Issues: #415

## Changes

- **Product license compliance export**

Adds a per-product export of the license distribution already shown on the Compliance tab. For each license associated with the product's packages, the export includes the SPDX key, short name, internal key, number of packages using it, and the compliance alert level (error/warning). Useful for sharing license posture with legal or compliance reviewers outside the application, and for feeding downstream audit tooling.

- **Product security compliance export**

Adds a per-product export of the vulnerabilities affecting the product's packages. For each vulnerability, the export includes the vulnerability ID, aliases (CVE, GHSA, PYSEC, etc.), summary, risk level and score, exploitability, weighted severity, number of affected and fixed packages within the product, and the reference URL. Useful for vulnerability triage reports, VEX-adjacent workflows, and security audits.

Both available as the following formats:

- Comma-separated Values (.csv)
- JSON (.json)
- OpenDocument (.ods)
- Microsoft Excel (.xlsx)
- YAML (.yaml)

## Screens

Available from the "Download" icon in both panel header of the "Product > Compliance tab"
<img width="350" alt="Screenshot 2026-04-24 at 09 40 34" src="https://github.com/user-attachments/assets/61f99867-cc03-4524-9700-1d4541a3ffc3" />

<img width="350" alt="Screenshot 2026-04-24 at 09 40 46" src="https://github.com/user-attachments/assets/384d0cf2-c0b9-4669-83ca-7f8b295857b1" />

