### PR TITLE
Fix REQUESTS_TIMEOUT by converting to int

### DIFF
--- a/dejacode_toolkit/__init__.py
+++ b/dejacode_toolkit/__init__.py
@@ -21,7 +21,7 @@ def get_settings(var_name, default=None):
     return getenv(var_name) or getattr(settings, var_name, default)
 
 
-REQUESTS_TIMEOUT = get_settings("DEJACODE_INTEGRATION_REQUESTS_TIMEOUT", default=5)
+REQUESTS_TIMEOUT = int(get_settings("DEJACODE_INTEGRATION_REQUESTS_TIMEOUT", default=5))
 
 
 def is_service_available(label, session, url, raise_exceptions):


### PR DESCRIPTION
The commit 65c725c5c18561268967435f4ee4d1147d47861d introduced `DEJACODE_INTEGRATION_REQUESTS_TIMEOUT` to control the timeout behavior for requests that DejaCode makes. The [dejacode_toolkit\__init__.py](dejacode_toolkit\__init__.py) uses the function `get_settings` which either returns `getenv` or `getattr`. Since `getenv` returns a string, the usage of `get_settings` must convert to int before assigning it to `REQUESTS_TIMEOUT`, otherwise requests will raise an exception for not receiving an int or float.

## Issues

- Closes: #525

## Changes

The return value of `get_settings` is converted into an integer, ensuring that in either case of `get_settings` `REQUESTS_TIMEOUT` contains an integer.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/aboutcode-org/dejacode/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [-] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR
