### PR TITLE
feat: [five-c] Compliance dashboards improved

### DIFF
--- a/dejacode/static/css/dejacode_bootstrap.css
+++ b/dejacode/static/css/dejacode_bootstrap.css
@@ -546,6 +546,9 @@ table.purldb-table .column-license_expression {
   color: white;
   vertical-align: middle;
 }
+.text-request {
+  color: var(--bs-djc-request-bg);
+}
 
 /* -- Requests form -- */
 #workflow-request-form fieldset.right-side label {

--- a/dejacode/static/js/dejacode_main.js
+++ b/dejacode/static/js/dejacode_main.js
@@ -206,6 +206,19 @@ function setupThemeSwitcher() {
   });
 }
 
+function setupPlatformHints() {
+  const isMac = navigator.userAgentData
+    ? navigator.userAgentData.platform === 'macOS'
+    : /Mac/.test(navigator.platform);
+
+  if (!isMac) return;
+
+  const searchSubmitKey = document.getElementById('search-submit-key');
+  if (searchSubmitKey) {
+    searchSubmitKey.textContent = 'Return';
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   NEXB = {};
   NEXB.client_data = JSON.parse(document.getElementById("client_data").textContent);
@@ -242,4 +255,5 @@ document.addEventListener('DOMContentLoaded', () => {
   setupHTMX();
   setupSearchModal();
   setupThemeSwitcher();
+  setupPlatformHints();
 });

--- a/dejacode/static/js/dejacode_main.js
+++ b/dejacode/static/js/dejacode_main.js
@@ -135,13 +135,24 @@ function setupSearchModal() {
 
   if (!searchModal) return;
 
+  // Apply a scope button as the active one and sync the form action
+  const applyScope = (button) => {
+    document.querySelectorAll('.search-scope-btn').forEach(b => b.classList.remove('active'));
+    button.classList.add('active');
+    searchForm.setAttribute('action', button.dataset.scopeAction);
+  };
+
+  // Sync form action with the currently active scope button on page load
+  const activeButton = document.querySelector('.search-scope-btn.active');
+  if (searchForm && activeButton) {
+    searchForm.setAttribute('action', activeButton.dataset.scopeAction);
+  }
+
   // Scope selector buttons
   if (searchForm) {
     document.querySelectorAll('.search-scope-btn').forEach(button => {
       button.addEventListener('click', () => {
-        document.querySelectorAll('.search-scope-btn').forEach(b => b.classList.remove('active'));
-        button.classList.add('active');
-        searchForm.setAttribute('action', button.dataset.scopeAction);
+        applyScope(button);
         searchInput.focus();
       });
     });

--- a/dejacode/static/js/dejacode_main.js
+++ b/dejacode/static/js/dejacode_main.js
@@ -219,6 +219,26 @@ function setupPlatformHints() {
   }
 }
 
+function setupDismissibleAlerts() {
+  // Hide announcements dismissed by the user via localStorage.
+  // The stored value is the announcement text itself, so when the
+  // admin updates the message, it automatically reappears for everyone.
+
+  const alert = document.getElementById('announcement-alert');
+  if (!alert) return;
+
+  const text = alert.textContent.trim();
+  if (localStorage.getItem('dismissed_announcement') === text) {
+    alert.remove();
+    return;
+  }
+
+  alert.classList.remove('d-none');
+  alert.addEventListener('closed.bs.alert', () => {
+    localStorage.setItem('dismissed_announcement', text);
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   NEXB = {};
   NEXB.client_data = JSON.parse(document.getElementById("client_data").textContent);
@@ -256,4 +276,5 @@ document.addEventListener('DOMContentLoaded', () => {
   setupSearchModal();
   setupThemeSwitcher();
   setupPlatformHints();
+  setupDismissibleAlerts();
 });

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -45,11 +45,11 @@
 
   {# Custom reporting cards #}
   {% if cards %}
-    <div class="row sm-gutter mb-3">
+    <div class="row row-cols-1 row-cols-lg-3 g-3 mb-3">
       {% for card in cards %}
-        <div class="col">
-          <div class="card shadow-sm">
-            <div class="h6 card-header fw-bold px-2">{{ card.title }}</div>
+        <div class="col d-flex">
+          <div class="card flex-fill shadow-sm">
+            <h2 class="card-header fw-bold px-2 h6">{{ card.title }}</h2>
             <div class="card-body p-2">
               {% for obj in card.object_list %}
                 {% if forloop.first %}
@@ -66,8 +66,8 @@
             {% if card.display_changelist_link and request.user.is_staff %}
               {% with changelist_url=card.query.get_changelist_url_with_filters %}
                 {% if changelist_url %}
-                  <div class="card-footer text-center p-2">
-                    <a href="{{ changelist_url }}" class="card-link smaller">View all the objects in changelist</a>
+                  <div class="card-footer text-center p-2 smaller">
+                    <a href="{{ changelist_url }}">View all the objects in changelist</a>
                   </div>
                 {% endif %}
               {% endwith %}

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -8,7 +8,7 @@
 {% block content %}
 
   {% block announcements %}
-    <div class="alert alert-success" role="alert">
+    <div id="announcement-alert" class="alert alert-success alert-dismissible d-none" role="alert">
       <strong>
         {% if user.dataspace.home_page_announcements %}
           {{ user.dataspace.home_page_announcements|urlize_target_blank|linebreaksbr }}
@@ -16,11 +16,12 @@
           Welcome to DejaCode!
         {% endif %}
       </strong>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
   {% endblock announcements %}
 
   {% block dataspace_header %}
-    <div class="card mt-1 mb-3">
+    <div class="card mb-3">
       <div class="card-body py-2 px-3">
         <div class="d-flex flex-wrap align-items-center justify-content-between">
           <div class="d-flex align-items-center gap-3">
@@ -49,7 +50,7 @@
     {% block compliance_card %}
       <div class="col d-flex">
         <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
-          <div class="h6 ms-4">
+          <div class="h6">
             <i class="fas fa-spinner fa-spin"></i>
           </div>
         </div>

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -78,7 +78,7 @@
     </div>
   {% endif %}
 
-  <div class="row row-cols-1 row-cols-lg-3 sm-gutter">
+  <div class="row row-cols-1 row-cols-lg-3 g-3 sm-gutter">
     {# Compliance #}
     <div class="col d-flex">
       <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -6,9 +6,6 @@
 {% block page_title %}DejaCode for {{ user.dataspace }}{% endblock %}
 
 {% block content %}
-  <h1 class="display-6 p-3 text-center">
-    DejaCode for <strong>{{ user.dataspace }}</strong>
-  </h1>
 
   {# Announcements #}
   <div class="alert alert-success" role="alert">
@@ -21,24 +18,27 @@
     </strong>
   </div>
 
-  {# Documentation and support links #}
-  <div class="card my-3">
+  {# Dataspace name and links #}
+  <div class="card mt-1 mb-3">
     <div class="card-body py-2 px-3">
-      <div class="d-flex flex-wrap align-items-center gap-2">
-        {% for header, urls in sections.items %}
-          {% if not forloop.first %}
-            <span class="mx-2 text-muted">|</span>
-          {% endif %}
-          <span class="fw-semibold text-body-secondary small text-uppercase me-1">
-            {{ header }}
+      <div class="d-flex flex-wrap align-items-center justify-content-between">
+        <div class="d-flex align-items-center gap-3">
+          <span class="h5 mb-0 fw-bold">
+            {{ user.dataspace }}
           </span>
-          {% for value, url in urls.items %}
-            {% if not forloop.first %}
-              <span class="text-muted small mx-1">|</span>
-            {% endif %}
-            <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
+          <div class="vr align-self-stretch my-1"></div>
+          <span class="text-body-secondary small">Dashboard</span>
+        </div>
+        <div class="d-flex flex-wrap align-items-baseline gap-1">
+          {% for header, urls in sections.items %}
+            {% for value, url in urls.items %}
+              {% if not forloop.parentloop.first or not forloop.first %}
+                <span class="text-muted small mx-1">|</span>
+              {% endif %}
+              <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
+            {% endfor %}
           {% endfor %}
-        {% endfor %}
+        </div>
       </div>
     </div>
   </div>

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -7,65 +7,67 @@
 
 {% block content %}
 
-  {# Announcements #}
-  <div class="alert alert-success" role="alert">
-    <strong>
-      {% if user.dataspace.home_page_announcements %}
-        {{ user.dataspace.home_page_announcements|urlize_target_blank|linebreaksbr }}
-      {% else %}
-        Welcome to DejaCode!
-      {% endif %}
-    </strong>
-  </div>
+  {% block announcements %}
+    <div class="alert alert-success" role="alert">
+      <strong>
+        {% if user.dataspace.home_page_announcements %}
+          {{ user.dataspace.home_page_announcements|urlize_target_blank|linebreaksbr }}
+        {% else %}
+          Welcome to DejaCode!
+        {% endif %}
+      </strong>
+    </div>
+  {% endblock announcements %}
 
-  {# Dataspace name and links #}
-  <div class="card mt-1 mb-3">
-    <div class="card-body py-2 px-3">
-      <div class="d-flex flex-wrap align-items-center justify-content-between">
-        <div class="d-flex align-items-center gap-3">
-          <span class="h5 mb-0 fw-bold">
-            {{ user.dataspace }}
-          </span>
-          <div class="vr align-self-stretch my-1"></div>
-          <span class="text-body-secondary small">Dashboard</span>
-        </div>
-        <div class="d-flex flex-wrap align-items-baseline gap-1">
-          {% for header, urls in sections.items %}
-            {% for value, url in urls.items %}
-              {% if not forloop.parentloop.first or not forloop.first %}
-                <span class="text-muted small mx-1">|</span>
-              {% endif %}
-              <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
+  {% block dataspace_header %}
+    <div class="card mt-1 mb-3">
+      <div class="card-body py-2 px-3">
+        <div class="d-flex flex-wrap align-items-center justify-content-between">
+          <div class="d-flex align-items-center gap-3">
+            <span class="h5 mb-0 fw-bold">
+              {{ user.dataspace }}
+            </span>
+            <div class="vr align-self-stretch my-1"></div>
+            <span class="text-body-secondary small">Dashboard</span>
+          </div>
+          <div class="d-flex flex-wrap align-items-baseline gap-1">
+            {% for header, urls in sections.items %}
+              {% for value, url in urls.items %}
+                {% if not forloop.parentloop.first or not forloop.first %}
+                  <span class="text-muted small mx-1">|</span>
+                {% endif %}
+                <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
+              {% endfor %}
             {% endfor %}
-          {% endfor %}
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  {% endblock dataspace_header %}
 
   <div class="row row-cols-1 row-cols-lg-3 g-3 sm-gutter mb-3">
-    {# Compliance #}
-    <div class="col d-flex">
-      <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
-        <div class="h6 ms-4">
-          <i class="fas fa-spinner fa-spin"></i>
+    {% block compliance_card %}
+      <div class="col d-flex">
+        <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
+          <div class="h6 ms-4">
+            <i class="fas fa-spinner fa-spin"></i>
+          </div>
         </div>
       </div>
-    </div>
-    {# Requests #}
-    {% if request_assigned_to_me or request_followed_by_me %}
-      <div class="col d-flex">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Assigned to me' header_icon='fa-user-check' filter_name='assignee' %}
-      </div>
-      <div class="col d-flex">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' filter_name='following' %}
-      </div>
-    {% endif %}
-  </div>
+    {% endblock compliance_card %}
 
-  {# Custom reporting cards #}
-  {% if cards %}
-    <div class="row row-cols-1 row-cols-lg-3 g-3">
+    {% block request_cards %}
+      {% if request_assigned_to_me or request_followed_by_me %}
+        <div class="col d-flex">
+          {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Assigned to me' header_icon='fa-user-check' filter_name='assignee' %}
+        </div>
+        <div class="col d-flex">
+          {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' filter_name='following' %}
+        </div>
+      {% endif %}
+    {% endblock request_cards %}
+
+    {% block custom_reporting_cards %}
       {% for card in cards %}
         <div class="col d-flex">
           <div class="card flex-fill shadow-sm">
@@ -95,6 +97,7 @@
           </div>
         </div>
       {% endfor %}
-    </div>
-  {% endif %}
+    {% endblock custom_reporting_cards %}
+
+  </div>
 {% endblock %}

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -43,7 +43,7 @@
     </div>
   </div>
 
-  <div class="row row-cols-1 row-cols-lg-3 g-3 sm-gutter">
+  <div class="row row-cols-1 row-cols-lg-3 g-3 sm-gutter mb-3">
     {# Compliance #}
     <div class="col d-flex">
       <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
@@ -65,7 +65,7 @@
 
   {# Custom reporting cards #}
   {% if cards %}
-    <div class="row row-cols-1 row-cols-lg-3 g-3 mb-3">
+    <div class="row row-cols-1 row-cols-lg-3 g-3">
       {% for card in cards %}
         <div class="col d-flex">
           <div class="card flex-fill shadow-sm">

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -10,6 +10,7 @@
     DejaCode for <strong>{{ user.dataspace }}</strong>
   </h1>
 
+  {# Announcements #}
   <div class="alert alert-success" role="alert">
     <strong>
       {% if user.dataspace.home_page_announcements %}
@@ -18,6 +19,28 @@
         Welcome to DejaCode!
       {% endif %}
     </strong>
+  </div>
+
+  {# Documentation and support links #}
+  <div class="card my-3">
+    <div class="card-body py-2 px-3">
+      <div class="d-flex flex-wrap align-items-center gap-2">
+        {% for header, urls in sections.items %}
+          {% if not forloop.first %}
+            <span class="mx-2 text-muted">|</span>
+          {% endif %}
+          <span class="fw-semibold text-body-secondary small text-uppercase me-1">
+            {{ header }}
+          </span>
+          {% for value, url in urls.items %}
+            {% if not forloop.first %}
+              <span class="text-muted small mx-1">|</span>
+            {% endif %}
+            <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
+          {% endfor %}
+        {% endfor %}
+      </div>
+    </div>
   </div>
 
   {# Custom reporting cards #}
@@ -55,8 +78,7 @@
     </div>
   {% endif %}
 
-
-<div class="row row-cols-1 row-cols-lg-3 sm-gutter">
+  <div class="row row-cols-1 row-cols-lg-3 sm-gutter">
     {# Compliance #}
     <div class="col">
       <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
@@ -74,28 +96,5 @@
         {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' filter_name='following' %}
       </div>
     {% endif %}
-  </div>
-
-  {# Documentation and support links #}
-  <div class="card mt-3">
-    <div class="card-body py-2 px-3">
-      <div class="d-flex flex-wrap align-items-center gap-2">
-        {% for header, urls in sections.items %}
-          {% if not forloop.first %}
-            <span class="mx-2 text-muted">|</span>
-          {% endif %}
-          <span class="fw-semibold text-body-secondary small text-uppercase me-1">
-            {{ header }}
-          </span>
-          {% for value, url in urls.items %}
-            {% if not forloop.first %}
-              <span class="text-muted small mx-1">|</span>
-            {% endif %}
-            <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
-          {% endfor %}
-        {% endfor %}
-      </div>
-    </div>
-
   </div>
 {% endblock %}

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -80,7 +80,7 @@
 
   <div class="row row-cols-1 row-cols-lg-3 sm-gutter">
     {# Compliance #}
-    <div class="col">
+    <div class="col d-flex">
       <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
         <div class="h6 ms-4">
           <i class="fas fa-spinner fa-spin"></i>
@@ -89,10 +89,10 @@
     </div>
     {# Requests #}
     {% if request_assigned_to_me or request_followed_by_me %}
-      <div class="col">
+      <div class="col d-flex">
         {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Assigned to me' header_icon='fa-user-check' filter_name='assignee' %}
       </div>
-      <div class="col">
+      <div class="col d-flex">
         {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' filter_name='following' %}
       </div>
     {% endif %}

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -20,6 +20,7 @@
     </strong>
   </div>
 
+  {# Custom reporting cards #}
   {% if cards %}
     <div class="row sm-gutter mb-3">
       {% for card in cards %}
@@ -55,6 +56,26 @@
   {% endif %}
 
   <div class="row row-cols-3 sm-gutter">
+    {# Compliance #}
+    <div class="col">
+      <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
+        <div class="h6 ms-4">
+          <i class="fas fa-spinner fa-spin"></i> Fetching...
+        </div>
+      </div>
+    </div>
+
+    {# Requests #}
+    {% if request_assigned_to_me or request_followed_by_me %}
+      <div class="col">
+        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Requests assigned to me' filter_name='assignee' %}
+      </div>
+      <div class="col">
+        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Requests I am following' filter_name='following' %}
+      </div>
+    {% endif %}
+
+    {# Documentation and support links #}
     <div class="col">
       <div class="card">
         <div class="card-body pb-1">
@@ -69,14 +90,5 @@
         </div>
       </div>
     </div>
-
-    {% if request_assigned_to_me or request_followed_by_me %}
-      <div class="col">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Requests assigned to me' filter_name='assignee' %}
-      </div>
-      <div class="col">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Requests I am following' filter_name='following' %}
-      </div>
-    {% endif %}
   </div>
 {% endblock %}

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -43,6 +43,26 @@
     </div>
   </div>
 
+  <div class="row row-cols-1 row-cols-lg-3 g-3 sm-gutter">
+    {# Compliance #}
+    <div class="col d-flex">
+      <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
+        <div class="h6 ms-4">
+          <i class="fas fa-spinner fa-spin"></i>
+        </div>
+      </div>
+    </div>
+    {# Requests #}
+    {% if request_assigned_to_me or request_followed_by_me %}
+      <div class="col d-flex">
+        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Assigned to me' header_icon='fa-user-check' filter_name='assignee' %}
+      </div>
+      <div class="col d-flex">
+        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' filter_name='following' %}
+      </div>
+    {% endif %}
+  </div>
+
   {# Custom reporting cards #}
   {% if cards %}
     <div class="row row-cols-1 row-cols-lg-3 g-3 mb-3">
@@ -77,24 +97,4 @@
       {% endfor %}
     </div>
   {% endif %}
-
-  <div class="row row-cols-1 row-cols-lg-3 g-3 sm-gutter">
-    {# Compliance #}
-    <div class="col d-flex">
-      <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
-        <div class="h6 ms-4">
-          <i class="fas fa-spinner fa-spin"></i>
-        </div>
-      </div>
-    </div>
-    {# Requests #}
-    {% if request_assigned_to_me or request_followed_by_me %}
-      <div class="col d-flex">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Assigned to me' header_icon='fa-user-check' filter_name='assignee' %}
-      </div>
-      <div class="col d-flex">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' filter_name='following' %}
-      </div>
-    {% endif %}
-  </div>
 {% endblock %}

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -55,7 +55,7 @@
     </div>
   {% endif %}
 
-  <div class="row row-cols-3 sm-gutter">
+  <div class="row row-cols-1 row-cols-lg-3 sm-gutter">
     {# Compliance #}
     <div class="col">
       <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
@@ -64,39 +64,35 @@
         </div>
       </div>
     </div>
-
     {# Requests #}
     {% if request_assigned_to_me or request_followed_by_me %}
       <div class="col">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Requests assigned to me' filter_name='assignee' %}
+        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Assigned to me' header_icon='fa-user-check' header_icon_color='text-primary' filter_name='assignee' card_accent='border-primary' %}
       </div>
       <div class="col">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Requests I am following' filter_name='following' %}
+        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' header_icon_color='text-purple' filter_name='following' card_accent='border-purple' %}
       </div>
     {% endif %}
+  </div>
 
-
-    {# Documentation and support links #}
-    <div class="col-12">
-      <div class="card">
-        <div class="card-body py-2 px-3">
-          <div class="d-flex flex-wrap align-items-center gap-2">
-            {% for header, urls in sections.items %}
-              {% if not forloop.first %}
-                <span class="mx-2 text-muted">|</span>
-              {% endif %}
-              <span class="fw-semibold text-body-secondary small text-uppercase me-1">
-                {{ header }}
-              </span>
-              {% for value, url in urls.items %}
-                {% if not forloop.first %}
-                  <span class="text-muted small mx-1">|</span>
-                {% endif %}
-                <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
-              {% endfor %}
-            {% endfor %}
-          </div>
-        </div>
+  {# Documentation and support links #}
+  <div class="card mt-3">
+    <div class="card-body py-2 px-3">
+      <div class="d-flex flex-wrap align-items-center gap-2">
+        {% for header, urls in sections.items %}
+          {% if not forloop.first %}
+            <span class="mx-2 text-muted">|</span>
+          {% endif %}
+          <span class="fw-semibold text-body-secondary small text-uppercase me-1">
+            {{ header }}
+          </span>
+          {% for value, url in urls.items %}
+            {% if not forloop.first %}
+              <span class="text-muted small mx-1">|</span>
+            {% endif %}
+            <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
+          {% endfor %}
+        {% endfor %}
       </div>
     </div>
 

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -55,7 +55,8 @@
     </div>
   {% endif %}
 
-  <div class="row row-cols-1 row-cols-lg-3 sm-gutter">
+
+<div class="row row-cols-1 row-cols-lg-3 sm-gutter">
     {# Compliance #}
     <div class="col">
       <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
@@ -67,10 +68,10 @@
     {# Requests #}
     {% if request_assigned_to_me or request_followed_by_me %}
       <div class="col">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Assigned to me' header_icon='fa-user-check' header_icon_color='text-primary' filter_name='assignee' card_accent='border-primary' %}
+        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_assigned_to_me header_title='Assigned to me' header_icon='fa-user-check' filter_name='assignee' %}
       </div>
       <div class="col">
-        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' header_icon_color='text-purple' filter_name='following' card_accent='border-purple' %}
+        {% include 'workflow/includes/request_home_dashboard.html' with request_qs=request_followed_by_me header_title='Following' header_icon='fa-eye' filter_name='following' %}
       </div>
     {% endif %}
   </div>

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -60,7 +60,7 @@
     <div class="col">
       <div hx-get="{% url 'product_portfolio:compliance_watchlist_card' %}" hx-trigger="load" hx-swap="outerHTML">
         <div class="h6 ms-4">
-          <i class="fas fa-spinner fa-spin"></i> Fetching...
+          <i class="fas fa-spinner fa-spin"></i>
         </div>
       </div>
     </div>

--- a/dje/templates/dataspace_home.html
+++ b/dje/templates/dataspace_home.html
@@ -75,20 +75,30 @@
       </div>
     {% endif %}
 
+
     {# Documentation and support links #}
-    <div class="col">
+    <div class="col-12">
       <div class="card">
-        <div class="card-body pb-1">
-          {% for header, urls in sections.items %}
-            <h2 class="h5">{{ header }}:</h2>
-            <ul class="ps-4">
+        <div class="card-body py-2 px-3">
+          <div class="d-flex flex-wrap align-items-center gap-2">
+            {% for header, urls in sections.items %}
+              {% if not forloop.first %}
+                <span class="mx-2 text-muted">|</span>
+              {% endif %}
+              <span class="fw-semibold text-body-secondary small text-uppercase me-1">
+                {{ header }}
+              </span>
               {% for value, url in urls.items %}
-                <li><a target="_blank" href="{{ url }}" rel="noreferrer">{{ value }}</a></li>
+                {% if not forloop.first %}
+                  <span class="text-muted small mx-1">|</span>
+                {% endif %}
+                <a href="{{ url }}" target="_blank" rel="noreferrer" class="small text-decoration-none">{{ value }}</a>
               {% endfor %}
-            </ul>
-          {% endfor %}
+            {% endfor %}
+          </div>
         </div>
       </div>
     </div>
+
   </div>
 {% endblock %}

--- a/dje/templates/modals/search_modal.html
+++ b/dje/templates/modals/search_modal.html
@@ -121,7 +121,7 @@
             </span>
             <span class="px-2">/</span>
             <span class="small text-body-secondary">
-              <kbd class="small">Enter</kbd> {% trans "to search" %}
+              <kbd class="small" id="search-submit-key">Enter</kbd> {% trans "to search" %}
             </span>
           </div>
         </div>

--- a/dje/templates/modals/search_modal.html
+++ b/dje/templates/modals/search_modal.html
@@ -15,22 +15,50 @@
 
         {# Scope selector #}
         <div class="p-3 border-bottom">
-          <div class="text-body-secondary small text-uppercase fw-semibold mb-2">{% trans "Search in" %}</div>
-          <div class="d-flex flex-wrap gap-2" id="search-scope-buttons">
-            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if not product_list_url in request.path and not component_list_url in request.path and not package_list_url in request.path and not license_list_url in request.path and not owner_list_url in request.path %}active{% endif %}" data-scope-action="{{ global_search_url }}" data-scope-label="<i class='fa fa-globe'></i> {% trans 'Global' %}">
+          <div class="text-body-secondary small text-uppercase fw-semibold mb-2">
+            {% trans "Search in" %}
+          </div>
+          {# Catalogs #}
+          <div class="d-flex flex-wrap gap-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if not product_list_url in request.path and not component_list_url in request.path and not package_list_url in request.path and not license_list_url in request.path and not owner_list_url in request.path and not request_list_url in request.path and not report_list_url in request.path and not vulnerability_list_url in request.path and not purldb_list_url in request.path %}active{% endif %}" data-scope-action="{{ global_search_url }}">
               <i class="fa fa-globe me-1"></i>{% trans "Global" %}
             </button>
             {% if not user.is_anonymous %}
-              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if product_list_url in request.path %}active{% endif %}" data-scope-action="{{ product_list_url }}" data-scope-label="<i class='fa fa-briefcase'></i> {% trans 'Product' %}">
+              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if product_list_url in request.path %}active{% endif %}" data-scope-action="{{ product_list_url }}">
                 <i class="fa fa-briefcase me-1"></i>{% trans "Product" %}
               </button>
             {% endif %}
-            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if package_list_url in request.path %}active{% endif %}" data-scope-action="{{ package_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}" data-scope-label="<i class='fas fa-archive'></i> {% trans 'Package' %}">
+            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if package_list_url in request.path %}active{% endif %}" data-scope-action="{{ package_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
               <i class="fas fa-archive me-1"></i>{% trans "Package" %}
             </button>
-            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if license_list_url in request.path %}active{% endif %}" data-scope-action="{{ license_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}" data-scope-label="<i class='fa fa-book'></i> {% trans 'License' %}">
+            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if license_list_url in request.path %}active{% endif %}" data-scope-action="{{ license_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
               <i class="fa fa-book me-1"></i>{% trans "License" %}
             </button>
+          </div>
+
+          {# Tools and integrations #}
+          <div class="d-flex flex-wrap gap-2 mt-3">
+            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if request_list_url in request.path %}active{% endif %}" data-scope-action="{{ request_list_url }}">
+              <span class="badge text-bg-request me-1">R</span>{% trans "Request" %}
+            </button>
+            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if report_list_url in request.path %}active{% endif %}" data-scope-action="{{ report_list_url }}">
+              <i class="fa fa-chart-bar me-1"></i>{% trans "Report" %}
+            </button>
+            {% if user.dataspace.enable_vulnerablecodedb_access %}
+              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if vulnerability_list_url in request.path %}active{% endif %}" data-scope-action="{{ vulnerability_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
+                <i class="fas fa-bug me-1"></i>{% trans "Vulnerability" %}
+              </button>
+            {% endif %}
+            {% if user.dataspace.enable_package_scanning %}
+              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if scan_list_url in request.path %}active{% endif %}" data-scope-action="{{ scan_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
+                <i class="fas fa-barcode me-1"></i>{% trans "Scan" %}
+              </button>
+            {% endif %}
+            {% if user.dataspace.enable_purldb_access %}
+              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if purldb_list_url in request.path %}active{% endif %}" data-scope-action="{{ purldb_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
+                <i class="fas fa-database me-1"></i>{% trans "PurlDB" %}
+              </button>
+            {% endif %}
           </div>
         </div>
 

--- a/dje/templates/modals/search_modal.html
+++ b/dje/templates/modals/search_modal.html
@@ -37,29 +37,31 @@
           </div>
 
           {# Tools and integrations #}
-          <div class="d-flex flex-wrap gap-2 mt-3">
-            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if request_list_url in request.path %}active{% endif %}" data-scope-action="{{ request_list_url }}">
-              <span class="badge text-bg-request me-1">R</span>{% trans "Request" %}
-            </button>
-            <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if report_list_url in request.path %}active{% endif %}" data-scope-action="{{ report_list_url }}">
-              <i class="fa fa-chart-bar me-1"></i>{% trans "Report" %}
-            </button>
-            {% if user.dataspace.enable_vulnerablecodedb_access %}
-              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if vulnerability_list_url in request.path %}active{% endif %}" data-scope-action="{{ vulnerability_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
-                <i class="fas fa-bug me-1"></i>{% trans "Vulnerability" %}
+          {% if not user.is_anonymous %}
+            <div class="d-flex flex-wrap gap-2 mt-3">
+              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if request_list_url in request.path %}active{% endif %}" data-scope-action="{{ request_list_url }}">
+                <span class="badge text-bg-request me-1">R</span>{% trans "Request" %}
               </button>
-            {% endif %}
-            {% if user.dataspace.enable_package_scanning %}
-              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if scan_list_url in request.path %}active{% endif %}" data-scope-action="{{ scan_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
-                <i class="fas fa-barcode me-1"></i>{% trans "Scan" %}
+              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if report_list_url in request.path %}active{% endif %}" data-scope-action="{{ report_list_url }}">
+                <i class="fa fa-chart-bar me-1"></i>{% trans "Report" %}
               </button>
-            {% endif %}
-            {% if user.dataspace.enable_purldb_access %}
-              <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if purldb_list_url in request.path %}active{% endif %}" data-scope-action="{{ purldb_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
-                <i class="fas fa-database me-1"></i>{% trans "PurlDB" %}
-              </button>
-            {% endif %}
-          </div>
+              {% if user.dataspace.enable_vulnerablecodedb_access %}
+                <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if vulnerability_list_url in request.path %}active{% endif %}" data-scope-action="{{ vulnerability_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
+                  <i class="fas fa-bug me-1"></i>{% trans "Vulnerability" %}
+                </button>
+              {% endif %}
+              {% if user.dataspace.enable_package_scanning %}
+                <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if scan_list_url in request.path %}active{% endif %}" data-scope-action="{{ scan_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
+                  <i class="fas fa-barcode me-1"></i>{% trans "Scan" %}
+                </button>
+              {% endif %}
+              {% if user.dataspace.enable_purldb_access %}
+                <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill search-scope-btn {% if purldb_list_url in request.path %}active{% endif %}" data-scope-action="{{ purldb_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}">
+                  <i class="fas fa-database me-1"></i>{% trans "PurlDB" %}
+                </button>
+              {% endif %}
+            </div>
+          {% endif %}
         </div>
 
         {# Carry over current list filters into the search #}

--- a/dje/templates/modals/search_modal.html
+++ b/dje/templates/modals/search_modal.html
@@ -2,7 +2,7 @@
 <div id="search-modal" class="modal fade" tabindex="-1" aria-labelledby="search-modal-label" aria-hidden="true">
   <div class="modal-dialog modal-lg mt-5">
     <div class="modal-content">
-      <form id="search-form" role="search" class="d-flex flex-column" action="{% if product_list_url in request.path %}{{ product_list_url }}{% elif component_list_url in request.path %}{{ component_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}{% elif package_list_url in request.path %}{{ package_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}{% elif license_list_url in request.path %}{{ license_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}{% elif owner_list_url in request.path %}{{ owner_list_url }}{% if is_reference_data %}{{ dataspace.name }}{% endif %}{% else %}{{ global_search_url }}{% endif %}">
+      <form id="search-form" role="search" class="d-flex flex-column" action="{{ global_search_url }}">
 
         {# Search input #}
         <div class="input-group input-group-lg border-bottom">

--- a/dje/templates/navbar/navbar_header.html
+++ b/dje/templates/navbar/navbar_header.html
@@ -10,6 +10,7 @@
 {% url 'component_catalog:scan_list' as scan_list_url %}
 {% url 'purldb:purldb_list' as purldb_list_url %}
 {% url 'vulnerabilities:vulnerability_list' as vulnerability_list_url %}
+{% url 'account_profile' as account_profile_url %}
 
 {% block navbar %}
   <nav class="navbar navbar-expand-md fixed-top">

--- a/dje/templates/navbar/navbar_header.html
+++ b/dje/templates/navbar/navbar_header.html
@@ -6,6 +6,10 @@
 {% url 'django_registration_register' as register_url %}
 {% url 'global_search' as global_search_url %}
 {% url 'workflow:request_list' as request_list_url %}
+{% url 'reporting:report_list' as report_list_url %}
+{% url 'component_catalog:scan_list' as scan_list_url %}
+{% url 'purldb:purldb_list' as purldb_list_url %}
+{% url 'vulnerabilities:vulnerability_list' as vulnerability_list_url %}
 
 {% block navbar %}
   <nav class="navbar navbar-expand-md fixed-top">

--- a/dje/templates/navbar/navbar_header_right_menu.html
+++ b/dje/templates/navbar/navbar_header_right_menu.html
@@ -60,6 +60,12 @@
         </a>
         {% if user.is_staff %}
           <div class="dropdown-divider"></div>
+          <div class="dropdown-header">Administration</div>
+          <a class="dropdown-item" href="{% url 'admin:index' %}">
+            <i class="fas fa-tachometer-alt" aria-hidden="true"></i>
+            Admin Dashboard
+          </a>
+          <div class="dropdown-divider"></div>
           <div class="dropdown-header">Status</div>
           <a class="dropdown-item" href="{% url 'integrations_status' %}">
             <i class="fas fa-stethoscope"></i>

--- a/dje/templates/navbar/navbar_header_search_form.html
+++ b/dje/templates/navbar/navbar_header_search_form.html
@@ -2,8 +2,12 @@
 <li class="nav-item d-flex align-items-center me-3">
   <button type="button" class="btn btn-sm bg-body bg-opacity-10 border border-white border-opacity-25 text-white d-flex align-items-center rounded-pill px-2 nav-chip" data-bs-toggle="modal" data-bs-target="#search-modal" aria-label="{% trans 'Open search' %}">
     <i class="fas fa-magnifying-glass me-2 opacity-75"></i>
-    <span class="opacity-75 text-start flex-grow-1" style="min-width: 120px;">
-      {% trans "Search" %}
+    <span class="opacity-75 text-start flex-grow-1 text-truncate" style="width: 120px;">
+      {% if request.GET.q %}
+        {{ request.GET.q }}
+      {% else %}
+        {% trans "Search" %}
+      {% endif %}
     </span>
     <kbd class="ms-3 bg-white bg-opacity-10 text-white border border-white border-opacity-25 px-2 rounded fw-normal">/</kbd>
   </button>

--- a/dje/templates/navbar/side_menu.html
+++ b/dje/templates/navbar/side_menu.html
@@ -98,17 +98,17 @@
               {% trans "Integrations" %}
             </span>
           </li>
-          {% if user.dataspace.enable_package_scanning %}
-            <li class="nav-item">
-              <a href="{{ scan_list_url }}" class="nav-link text-body d-flex align-items-center {% if scan_list_url in request.path %}active{% endif %}">
-                <i class="fas fa-barcode fa-fw me-2"></i>{% trans "Scans" %}
-              </a>
-            </li>
-          {% endif %}
           {% if user.dataspace.enable_vulnerablecodedb_access %}
             <li class="nav-item">
               <a href="{{ vulnerability_list_url }}" class="nav-link text-body d-flex align-items-center {% if vulnerability_list_url in request.path %}active{% endif %}">
                 <i class="fas fa-bug fa-fw me-2"></i>{% trans "Vulnerabilities" %}
+              </a>
+            </li>
+          {% endif %}
+          {% if user.dataspace.enable_package_scanning %}
+            <li class="nav-item">
+              <a href="{{ scan_list_url }}" class="nav-link text-body d-flex align-items-center {% if scan_list_url in request.path %}active{% endif %}">
+                <i class="fas fa-barcode fa-fw me-2"></i>{% trans "Scans" %}
               </a>
             </li>
           {% endif %}

--- a/dje/templates/registration/login.html
+++ b/dje/templates/registration/login.html
@@ -9,9 +9,9 @@
 {% block content %}
   <h1>Sign in to DejaCode</h1>
 
-  <div class="row justify-content-md-center">
-    <div class="col-sm-4">
-      <div class="card">
+  <div class="row justify-content-center">
+    <div class="mx-auto" style="width: 400px;">
+      <div class="card shadow-sm">
         <div class="card-body">
           {% if AXES_ENABLED and form.errors %}
             <div class="alert alert-warning">

--- a/dje/tests/test_views.py
+++ b/dje/tests/test_views.py
@@ -64,7 +64,7 @@ class DJEViewsTestCase(TestCase):
         self.assertFalse(self.super_user.request_as_assignee.exists())
         self.assertFalse(self.super_user.request_as_requester.exists())
         self.assertContains(response, "Welcome to DejaCode!")
-        self.assertContains(response, "Documentation:")
+        self.assertContains(response, "Documentation")
 
         self.dataspace1.home_page_announcements = "Custom announcements"
         self.dataspace1.save()
@@ -89,8 +89,8 @@ class DJEViewsTestCase(TestCase):
         self.assertTrue(self.super_user.request_as_requester.exists())
 
         response = self.client.get(home_url)
-        self.assertContains(response, "Requests assigned to me")
-        self.assertContains(response, "Requests I am following")
+        self.assertContains(response, "Assigned to me")
+        self.assertContains(response, "Following")
         request_list_url = reverse("workflow:request_list")
         expected = f'<a href="{request_list_url}?following=yes">View all 1 requests</a>'
         self.assertContains(response, expected, html=True)
@@ -114,7 +114,7 @@ class DJEViewsTestCase(TestCase):
 
         response = self.client.get(home_url)
         self.assertContains(
-            response, '<div class="h6 card-header fw-bold px-2">Card1</div>', html=True
+            response, ' <h2 class="card-header fw-bold px-2 h6">Card1</h2>', html=True
         )
         self.assertContains(
             response,
@@ -122,8 +122,7 @@ class DJEViewsTestCase(TestCase):
             html=True,
         )
         changelist_link = (
-            f'<a href="/admin/organization/owner/?reporting_query={query.id}"'
-            f' class="card-link smaller">'
+            f'<a href="/admin/organization/owner/?reporting_query={query.id}">'
             f"  View all the objects in changelist"
             f"</a>"
         )

--- a/dje/views.py
+++ b/dje/views.py
@@ -704,7 +704,6 @@ def home_view(request):
         "Documentation": "https://dejacode.readthedocs.io/en/latest/",
         "Tutorials": f"{rtd_url}/tutorial-1.html",
         "API documentation": reverse("api-docs:docs-index"),
-        "How-To videos": "https://www.youtube.com/playlist?list=PLCq_LXeUqhkQj0u7M26fSHt1ebFhNCpCv",
     }
 
     support_urls = {

--- a/dje/views.py
+++ b/dje/views.py
@@ -701,8 +701,8 @@ def home_view(request):
     rtd_url = "https://dejacode.readthedocs.io/en/latest"
 
     documentation_urls = {
-        "Documentation": "https://dejacode.readthedocs.io/en/latest/",
         "Tutorials": f"{rtd_url}/tutorial-1.html",
+        "How-to": f"{rtd_url}/howto-1.html",
         "API documentation": reverse("api-docs:docs-index"),
     }
 

--- a/dje/views.py
+++ b/dje/views.py
@@ -1886,6 +1886,7 @@ class GlobalSearchListView(AcceptAnonymousMixin, TemplateView):
             )
 
         include_purldb_conditions = [
+            user.is_authenticated,
             user_dataspace.enable_purldb_access,
             PurlDB(user_dataspace).is_available(),
         ]

--- a/license_library/tests/test_views.py
+++ b/license_library/tests/test_views.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import resolve_url
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from dje.copier import copy_object
@@ -136,6 +137,7 @@ class LicenseListViewTestCase(TestCase):
             dataspace=self.nexb_dataspace,
         )
 
+    @override_settings(ANONYMOUS_USERS_DATASPACE=None)
     def test_license_library_list_view_access(self):
         license_list_url = resolve_url("license_library:license_list")
 

--- a/product_portfolio/models.py
+++ b/product_portfolio/models.py
@@ -15,6 +15,7 @@ from django.core.validators import MaxValueValidator
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.db.models import Case
+from django.db.models import CharField
 from django.db.models import Count
 from django.db.models import DecimalField
 from django.db.models import F
@@ -146,6 +147,18 @@ class ProductQuerySet(DataspacedQuerySet):
             ),
         )
 
+    def with_max_risk_level(self):
+        return self.annotate(
+            max_risk_level=Case(
+                When(max_risk_score__gte=8.0, then=Value("critical")),
+                When(max_risk_score__gte=6.0, then=Value("high")),
+                When(max_risk_score__gte=3.0, then=Value("medium")),
+                When(max_risk_score__gte=0.1, then=Value("low")),
+                default=Value(""),
+                output_field=CharField(max_length=8),
+            ),
+        )
+
     def with_vulnerability_counts(self):
         threshold_filter = Q(
             productpackages__package__affected_by_vulnerabilities__risk_score__gte=F(
@@ -191,6 +204,31 @@ class ProductQuerySet(DataspacedQuerySet):
                 filter=Q(productpackages__licenses__usage_policy__compliance_alert="error"),
                 distinct=True,
             ),
+        )
+
+    def with_compliance_data(self):
+        """Apply all compliance annotations and severity-based ordering."""
+        return (
+            self.with_risk_threshold()
+            .with_vulnerability_counts()
+            .with_license_compliance_counts()
+            .annotate(package_count=Count("productpackages", distinct=True))
+            .order_by(
+                F("max_risk_score").desc(nulls_last=True),
+                "-license_error_count",
+                "-license_warning_count",
+                "name",
+                "-version",
+            )
+        )
+
+    def with_compliance_issues(self):
+        """Filter to products that have license or critical/high vulnerability issues."""
+        return self.filter(
+            Q(license_error_count__gt=0)
+            | Q(license_warning_count__gt=0)
+            | Q(critical_count__gt=0)
+            | Q(high_count__gt=0)
         )
 
 

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
@@ -1,10 +1,12 @@
 <div class="card flex-fill shadow-sm">
   <h2 class="card-header fw-bold px-2 h6 d-flex justify-content-between align-items-center">
     <span>
-      <i class="fa-solid fa-shield-halved text-danger-emphasis me-1"></i>
+      <i class="fa-solid fa-shield-halved me-1"></i>
       Compliance watchlist
     </span>
-    <span class="badge bg-danger-subtle text-danger-emphasis">{{ total_products_with_issues }}</span>
+    {% if total_products_with_issues %}
+      <span class="badge bg-danger-subtle text-danger-emphasis">{{ total_products_with_issues }}</span>
+    {% endif %}
   </h2>
   <div class="card-body p-2">
     {% for product in compliance_qs %}
@@ -46,9 +48,20 @@
         </div>
       </div>
       {% if not forloop.last %}<hr class="my-2">{% endif %}
+    {% empty %}
+      <div class="text-center py-4">
+        <i class="fa-solid fa-circle-check text-success fs-3"></i>
+        <div class="mt-2 text-body-secondary">All products are compliant</div>
+      </div>
     {% endfor %}
   </div>
   <div class="card-footer text-center p-2 smaller">
-    <a href="{% url 'product_portfolio:compliance_dashboard' %}">View all {{ total_products_with_issues }} products with issues</a>
+    <a href="{% url 'product_portfolio:compliance_dashboard' %}">
+      {% if total_products_with_issues %}
+        View all {{ total_products_with_issues }} products with issues
+      {% else %}
+        View compliance dashboard
+      {% endif %}
+    </a>
   </div>
 </div>

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
@@ -1,4 +1,4 @@
-<div class="card mb-4 shadow-sm h-100">
+<div class="card flex-fill shadow-sm">
   <h2 class="card-header fw-bold px-2 h6 d-flex justify-content-between align-items-center">
     <span>
       <i class="fa-solid fa-shield-halved text-danger-emphasis me-1"></i>

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
@@ -1,7 +1,10 @@
 <div class="card mb-4 shadow-sm">
-  <h2 class="card-header fw-bold px-2 h6">
-    Compliance watchlist
-    <i class="fa-solid fa-shield-halved float-end"></i>
+  <h2 class="card-header fw-bold px-2 h6 d-flex justify-content-between align-items-center">
+    <span>
+      <i class="fa-solid fa-shield-halved text-warning me-1"></i>
+      Compliance watchlist
+    </span>
+    <span class="badge text-bg-warning">{{ total_products_with_issues }}</span>
   </h2>
   <div class="card-body p-2">
     {% for product in compliance_qs %}

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
@@ -1,10 +1,10 @@
 <div class="card mb-4 shadow-sm">
   <h2 class="card-header fw-bold px-2 h6 d-flex justify-content-between align-items-center">
     <span>
-      <i class="fa-solid fa-shield-halved text-warning me-1"></i>
+      <i class="fa-solid fa-shield-halved text-danger-emphasis me-1"></i>
       Compliance watchlist
     </span>
-    <span class="badge text-bg-warning">{{ total_products_with_issues }}</span>
+    <span class="badge bg-danger-subtle text-danger-emphasis">{{ total_products_with_issues }}</span>
   </h2>
   <div class="card-body p-2">
     {% for product in compliance_qs %}

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
@@ -1,4 +1,4 @@
-<div class="card mb-4 shadow-sm">
+<div class="card mb-4 shadow-sm h-100">
   <h2 class="card-header fw-bold px-2 h6 d-flex justify-content-between align-items-center">
     <span>
       <i class="fa-solid fa-shield-halved text-danger-emphasis me-1"></i>

--- a/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
+++ b/product_portfolio/templates/product_portfolio/compliance/compliance_watchlist_card.html
@@ -1,0 +1,51 @@
+<div class="card mb-4 shadow-sm">
+  <h2 class="card-header fw-bold px-2 h6">
+    Compliance watchlist
+    <i class="fa-solid fa-shield-halved float-end"></i>
+  </h2>
+  <div class="card-body p-2">
+    {% for product in compliance_qs %}
+      <div>
+        <a class="fw-semibold" href="{{ product.get_absolute_url }}#compliance">{{ product }}</a>
+        <div class="row g-0 small">
+          <div class="col-4 text-body-secondary">License</div>
+          <div class="col-8">
+            {% if product.license_error_count %}
+              <span class="badge bg-danger-subtle text-danger-emphasis">{{ product.license_error_count }} error{{ product.license_error_count|pluralize }}</span>
+            {% endif %}
+            {% if product.license_warning_count %}
+              <span class="badge bg-warning-subtle text-warning-emphasis{% if product.license_error_count %} ms-1{% endif %}">{{ product.license_warning_count }} warning{{ product.license_warning_count|pluralize }}</span>
+            {% endif %}
+            {% if not product.license_error_count and not product.license_warning_count %}
+              <span class="badge bg-success-subtle text-success-emphasis">OK</span>
+            {% endif %}
+          </div>
+        </div>
+        <div class="row g-0 small">
+          <div class="col-4 text-body-secondary">Vulnerabilities</div>
+          <div class="col-8">
+            {% if product.critical_count %}
+              <span class="badge bg-danger-subtle text-danger-emphasis">{{ product.critical_count }} critical</span>
+            {% endif %}
+            {% if product.high_count %}
+              <span class="badge bg-warning-orange-subtle text-warning-orange{% if product.critical_count %} ms-1{% endif %}">{{ product.high_count }} high</span>
+            {% endif %}
+            {% if product.medium_count %}
+              <span class="badge bg-warning-subtle text-warning-emphasis{% if product.critical_count or product.high_count %} ms-1{% endif %}">{{ product.medium_count }} medium</span>
+            {% endif %}
+            {% if product.low_count %}
+              <span class="badge bg-info-subtle text-info-emphasis{% if product.critical_count or product.high_count or product.medium_count %} ms-1{% endif %}">{{ product.low_count }} low</span>
+            {% endif %}
+            {% if not product.critical_count and not product.high_count and not product.medium_count and not product.low_count %}
+              <span class="text-body-tertiary">None</span>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+      {% if not forloop.last %}<hr class="my-2">{% endif %}
+    {% endfor %}
+  </div>
+  <div class="card-footer text-center p-2 smaller">
+    <a href="{% url 'product_portfolio:compliance_dashboard' %}">View all {{ total_products_with_issues }} products with issues</a>
+  </div>
+</div>

--- a/product_portfolio/urls.py
+++ b/product_portfolio/urls.py
@@ -10,6 +10,7 @@ from django.urls import path
 
 from product_portfolio.views import AttributionView
 from product_portfolio.views import ComplianceDashboardView
+from product_portfolio.views import ComplianceWatchlistCardView
 from product_portfolio.views import ImportManifestsView
 from product_portfolio.views import LoadSBOMsView
 from product_portfolio.views import ManageComponentGridView
@@ -72,6 +73,11 @@ urlpatterns = [
         "compliance_dashboard/",
         ComplianceDashboardView.as_view(),
         name="compliance_dashboard",
+    ),
+    path(
+        "compliance_watchlist/",
+        ComplianceWatchlistCardView.as_view(),
+        name="compliance_watchlist_card",
     ),
     path(
         "import_packages_from_scancodeio/<str:key>/",

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -3035,7 +3035,10 @@ class ComplianceWatchlistCardView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         products_with_issues = (
-            get_viewable_products(self.request.user).with_compliance_data().with_compliance_issues()
+            get_viewable_products(self.request.user)
+            .with_compliance_data()
+            .with_compliance_issues()
+            .none()
         )
         context["compliance_qs"] = products_with_issues[: self.limit]
         context["total_products_with_issues"] = products_with_issues.count()

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -25,8 +25,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db import transaction
-from django.db.models import Case
-from django.db.models import CharField
 from django.db.models import Count
 from django.db.models import Exists
 from django.db.models import F
@@ -35,8 +33,6 @@ from django.db.models import Prefetch
 from django.db.models import Q
 from django.db.models import Subquery
 from django.db.models import Sum
-from django.db.models import Value
-from django.db.models import When
 from django.db.models.functions import Lower
 from django.forms import modelformset_factory
 from django.http import FileResponse
@@ -58,7 +54,6 @@ from django.views.decorators.http import require_http_methods
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView
 from django.views.generic import FormView
-from django.views.generic import ListView
 from django.views.generic import TemplateView
 from django.views.generic.detail import BaseDetailView
 
@@ -2950,36 +2945,13 @@ class ExportComplianceMixin:
         return response
 
 
-def get_compliance_queryset(user):
-    """Return all viewable products annotated for compliance and severity-sorted."""
-    base_qs = Product.objects.get_queryset(
+def get_viewable_products(user):
+    """Return active, unlocked products the user can view."""
+    return Product.objects.get_queryset(
         user=user,
         perms="view_product",
         include_inactive=False,
         exclude_locked=True,
-    )
-    return (
-        base_qs.with_risk_threshold()
-        .with_vulnerability_counts()
-        .with_license_compliance_counts()
-        .annotate(
-            package_count=Count("productpackages", distinct=True),
-            max_risk_level=Case(
-                When(max_risk_score__gte=8.0, then=Value("critical")),
-                When(max_risk_score__gte=6.0, then=Value("high")),
-                When(max_risk_score__gte=3.0, then=Value("medium")),
-                When(max_risk_score__gte=0.1, then=Value("low")),
-                default=Value(""),
-                output_field=CharField(max_length=8),
-            ),
-        )
-        .order_by(
-            F("max_risk_score").desc(nulls_last=True),
-            "-license_error_count",
-            "-license_warning_count",
-            "name",
-            "-version",
-        )
     )
 
 
@@ -3007,7 +2979,7 @@ class ComplianceDashboardView(LoginRequiredMixin, ExportComplianceMixin, Dataspa
     }
 
     def get_queryset(self):
-        return get_compliance_queryset(self.request.user)
+        return get_viewable_products(self.request.user).with_compliance_data().with_max_risk_level()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -3015,12 +2987,7 @@ class ComplianceDashboardView(LoginRequiredMixin, ExportComplianceMixin, Dataspa
         products = self.object_list
         total_products = products.count()
 
-        products_with_issues = products.filter(
-            Q(license_error_count__gt=0)
-            | Q(license_warning_count__gt=0)
-            | Q(critical_count__gt=0)
-            | Q(high_count__gt=0)
-        ).count()
+        products_with_issues = products.with_compliance_issues().count()
 
         products_with_license_issues = products.filter(
             Q(license_error_count__gt=0) | Q(license_warning_count__gt=0)
@@ -3055,36 +3022,23 @@ class ComplianceDashboardView(LoginRequiredMixin, ExportComplianceMixin, Dataspa
         return context
 
 
-def get_products_with_compliance_issues(user):
-    """Filter the compliance queryset to products that need attention."""
-    return get_compliance_queryset(user).filter(
-        Q(license_error_count__gt=0)
-        | Q(license_warning_count__gt=0)
-        | Q(critical_count__gt=0)
-        | Q(high_count__gt=0)
-    )
-
-
 class ComplianceWatchlistCardView(
     LoginRequiredMixin,
     BaseProductViewMixin,
-    DataspaceScopeMixin,
-    ListView,
+    TemplateView,
 ):
     """HTMX partial: top products with compliance issues for the home dashboard."""
 
     template_name = "product_portfolio/compliance/compliance_watchlist_card.html"
-    context_object_name = "compliance_qs"
     limit = 5
-
-    def get_queryset(self):
-        return get_products_with_compliance_issues(self.request.user)[: self.limit]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["total_products_with_issues"] = get_products_with_compliance_issues(
-            self.request.user
-        ).count()
+        products_with_issues = (
+            get_viewable_products(self.request.user).with_compliance_data().with_compliance_issues()
+        )
+        context["compliance_qs"] = products_with_issues[: self.limit]
+        context["total_products_with_issues"] = products_with_issues.count()
         return context
 
 

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -3035,9 +3035,7 @@ class ComplianceWatchlistCardView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         products_with_issues = (
-            get_viewable_products(self.request.user)
-            .with_compliance_data()
-            .with_compliance_issues()
+            get_viewable_products(self.request.user).with_compliance_data().with_compliance_issues()
         )
         context["compliance_qs"] = products_with_issues[: self.limit]
         context["total_products_with_issues"] = products_with_issues.count()

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -58,6 +58,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView
 from django.views.generic import FormView
+from django.views.generic import ListView
 from django.views.generic import TemplateView
 from django.views.generic.detail import BaseDetailView
 
@@ -2949,6 +2950,39 @@ class ExportComplianceMixin:
         return response
 
 
+def get_compliance_queryset(user):
+    """Return all viewable products annotated for compliance and severity-sorted."""
+    base_qs = Product.objects.get_queryset(
+        user=user,
+        perms="view_product",
+        include_inactive=False,
+        exclude_locked=True,
+    )
+    return (
+        base_qs.with_risk_threshold()
+        .with_vulnerability_counts()
+        .with_license_compliance_counts()
+        .annotate(
+            package_count=Count("productpackages", distinct=True),
+            max_risk_level=Case(
+                When(max_risk_score__gte=8.0, then=Value("critical")),
+                When(max_risk_score__gte=6.0, then=Value("high")),
+                When(max_risk_score__gte=3.0, then=Value("medium")),
+                When(max_risk_score__gte=0.1, then=Value("low")),
+                default=Value(""),
+                output_field=CharField(max_length=8),
+            ),
+        )
+        .order_by(
+            F("max_risk_score").desc(nulls_last=True),
+            "-license_error_count",
+            "-license_warning_count",
+            "name",
+            "-version",
+        )
+    )
+
+
 class ComplianceDashboardView(LoginRequiredMixin, ExportComplianceMixin, DataspacedFilterView):
     """Compliance control center: overview of all products."""
 
@@ -2973,36 +3007,7 @@ class ComplianceDashboardView(LoginRequiredMixin, ExportComplianceMixin, Dataspa
     }
 
     def get_queryset(self):
-        base_qs = Product.objects.get_queryset(
-            user=self.request.user,
-            perms="view_product",
-            include_inactive=False,
-            exclude_locked=True,
-        )
-
-        return (
-            base_qs.with_risk_threshold()
-            .with_vulnerability_counts()
-            .with_license_compliance_counts()
-            .annotate(
-                package_count=Count("productpackages", distinct=True),
-                max_risk_level=Case(
-                    When(max_risk_score__gte=8.0, then=Value("critical")),
-                    When(max_risk_score__gte=6.0, then=Value("high")),
-                    When(max_risk_score__gte=3.0, then=Value("medium")),
-                    When(max_risk_score__gte=0.1, then=Value("low")),
-                    default=Value(""),
-                    output_field=CharField(max_length=8),
-                ),
-            )
-            .order_by(
-                F("max_risk_score").desc(nulls_last=True),
-                "-license_error_count",
-                "-license_warning_count",
-                "name",
-                "-version",
-            )
-        )
+        return get_compliance_queryset(self.request.user)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -3047,6 +3052,39 @@ class ComplianceDashboardView(LoginRequiredMixin, ExportComplianceMixin, Dataspa
             }
         )
 
+        return context
+
+
+def get_products_with_compliance_issues(user):
+    """Filter the compliance queryset to products that need attention."""
+    return get_compliance_queryset(user).filter(
+        Q(license_error_count__gt=0)
+        | Q(license_warning_count__gt=0)
+        | Q(critical_count__gt=0)
+        | Q(high_count__gt=0)
+    )
+
+
+class ComplianceWatchlistCardView(
+    LoginRequiredMixin,
+    BaseProductViewMixin,
+    DataspaceScopeMixin,
+    ListView,
+):
+    """HTMX partial: top products with compliance issues for the home dashboard."""
+
+    template_name = "product_portfolio/compliance/compliance_watchlist_card.html"
+    context_object_name = "compliance_qs"
+    limit = 5
+
+    def get_queryset(self):
+        return get_products_with_compliance_issues(self.request.user)[: self.limit]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["total_products_with_issues"] = get_products_with_compliance_issues(
+            self.request.user
+        ).count()
         return context
 
 

--- a/product_portfolio/views.py
+++ b/product_portfolio/views.py
@@ -3038,7 +3038,6 @@ class ComplianceWatchlistCardView(
             get_viewable_products(self.request.user)
             .with_compliance_data()
             .with_compliance_issues()
-            .none()
         )
         context["compliance_qs"] = products_with_issues[: self.limit]
         context["total_products_with_issues"] = products_with_issues.count()

--- a/workflow/templates/workflow/includes/request_home_dashboard.html
+++ b/workflow/templates/workflow/includes/request_home_dashboard.html
@@ -1,5 +1,5 @@
 {% load humanize %}
-<div class="card mb-4 shadow-sm h-100">
+<div class="card flex-fill shadow-sm">
   <h2 class="card-header fw-bold px-2 h6 d-flex justify-content-between align-items-center">
     <span>
       <i class="fas {{ header_icon }} text-request me-1"></i>

--- a/workflow/templates/workflow/includes/request_home_dashboard.html
+++ b/workflow/templates/workflow/includes/request_home_dashboard.html
@@ -1,9 +1,11 @@
 {% load humanize %}
-
 <div class="card mb-4 shadow-sm">
-  <h2 class="card-header fw-bold px-2 h6">
-    {{ header_title }}
-    <span class="badge text-bg-request float-end">R</span>
+  <h2 class="card-header fw-bold px-2 h6 d-flex justify-content-between align-items-center">
+    <span>
+      <i class="fas {{ header_icon }} text-request me-1"></i>
+      {{ header_title }}
+    </span>
+    <span class="badge text-bg-request">{{ request_qs.count }}</span>
   </h2>
 
   <div class="card-body p-2">
@@ -47,13 +49,12 @@
   <div class="card-footer text-center p-2 smaller">
     {% if request_qs %}
       {% if filter_name == 'following' %}
-        <a href="{% url 'workflow:request_list' %}?following=yes">
-          {% else %}
-            <a href="{% url 'workflow:request_list' %}?{{ filter_name }}={{ request.user.username }}">
-          {% endif %}
-          View all {{ request_qs.count }} requests</a>
+        <a href="{% url 'workflow:request_list' %}?following=yes">View all {{ request_qs.count }} requests</a>
       {% else %}
-        <a href="{% url 'workflow:request_list' %}">View all requests</a>
+        <a href="{% url 'workflow:request_list' %}?{{ filter_name }}={{ request.user.username }}">View all {{ request_qs.count }} requests</a>
+      {% endif %}
+    {% else %}
+      <a href="{% url 'workflow:request_list' %}">View all requests</a>
     {% endif %}
   </div>
 

--- a/workflow/templates/workflow/includes/request_home_dashboard.html
+++ b/workflow/templates/workflow/includes/request_home_dashboard.html
@@ -1,5 +1,5 @@
 {% load humanize %}
-<div class="card mb-4 shadow-sm">
+<div class="card mb-4 shadow-sm h-100">
   <h2 class="card-header fw-bold px-2 h6 d-flex justify-content-between align-items-center">
     <span>
       <i class="fas {{ header_icon }} text-request me-1"></i>

--- a/workflow/templates/workflow/includes/request_home_dashboard.html
+++ b/workflow/templates/workflow/includes/request_home_dashboard.html
@@ -16,7 +16,7 @@
           <div class="small text-muted-darker">
             {% if req.last_modified_by %}
               <div>
-                Last edited <span title="{{ req.last_modified_date }}">{{ req.last_modified_date|naturaltime }}</span> by {{ req.last_modified_by.username }}
+                Edited <span title="{{ req.last_modified_date }}">{{ req.last_modified_date|naturaltime }}</span> by {{ req.last_modified_by.username }}
               </div>
             {% else %}
               <div>

--- a/workflow/templates/workflow/includes/request_list_table.html
+++ b/workflow/templates/workflow/includes/request_list_table.html
@@ -80,7 +80,7 @@
                         {{ req.requester.username }}
                       {% endif %}
                       {% if req.last_modified_by %}
-                        &#8226; Last edited <span title="{{ req.last_modified_date }}">{{ req.last_modified_date|naturaltime }}</span> by {{ req.last_modified_by.username }}
+                        &#8226; Edited <span title="{{ req.last_modified_date }}">{{ req.last_modified_date|naturaltime }}</span> by {{ req.last_modified_by.username }}
                       {% endif %}
                     </div>
                     {% if not exclude_product_context and req.product_context %}

--- a/workflow/templates/workflow/request_details.html
+++ b/workflow/templates/workflow/request_details.html
@@ -88,7 +88,7 @@
       &#8226; Assigned to <strong>{{ request_instance.assignee.username }}</strong>
     {% endif %}
     {% if request_instance.last_modified_by %}
-      &#8226; Last edited <span title="{{ request_instance.last_modified_date }}">{{ request_instance.last_modified_date|naturaltime }}</span> by <strong>{{ request_instance.last_modified_by.username }}</strong>
+      &#8226; Edited <span title="{{ request_instance.last_modified_date }}">{{ request_instance.last_modified_date|naturaltime }}</span> by <strong>{{ request_instance.last_modified_by.username }}</strong>
     {% endif %}
   </p>
 


### PR DESCRIPTION
## Issues

- Issue: #405

## Changes

- Add compliance watchlist card to the home dashboard
- Redesign the dashboard headers and cards
- Rework the documentation links of the dashboard
- Add admin dashboard link to the right dropdown menu 
- Add tools and integrations as scope selector for the search
- Dynamic display "Return" instead of "Enter" for Mac users in search modal
- Add dismissible homepage announcements with localStorage persistence

## Screens
<img width="2552" height="694" alt="Screenshot 2026-05-06 at 18 56 40" src="https://github.com/user-attachments/assets/c2d7ef4e-07d5-404f-8c2d-558fc098b279" />

---

<img width="300" alt="Screenshot 2026-05-05 at 18 38 03" src="https://github.com/user-attachments/assets/47c754b6-7eb2-4a4e-87c8-1c411f715cfd" />

---

<img width="1630" height="502" alt="Screenshot 2026-05-06 at 07 40 45" src="https://github.com/user-attachments/assets/e947743d-ee50-4b85-a07a-570840885f1f" />
