### PR TITLE
fix: improve performances and logging for SCIO importer

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -22,8 +22,6 @@ services:
   web:
     build: .
     image: dejacode:dev
-    env_file:
-      - .env
     environment:
       - DATABASE_HOST=db
       - DATABASE_PASSWORD=dejacode
@@ -37,6 +35,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
+      - ./.env:/opt/dejacode/.env
       - ./component_catalog:/opt/dejacode/component_catalog
       - ./dejacode:/opt/dejacode/dejacode
       - ./dejacode_toolkit:/opt/dejacode/dejacode_toolkit

--- a/dejacode/settings.py
+++ b/dejacode/settings.py
@@ -586,6 +586,11 @@ LOGGING = {
             "propagate": False,
             "level": DEJACODE_LOG_LEVEL,
         },
+        "product_portfolio": {
+            "handlers": ["null"] if IS_TESTS else ["console"],
+            "propagate": False,
+            "level": "DEBUG" if DEBUG else DEJACODE_LOG_LEVEL,
+        },
     },
 }
 
@@ -717,6 +722,7 @@ URLIZE_ASSUME_HTTPS = env.bool("DEJACODE_URLIZE_ASSUME_HTTPS", default=True)
 
 # Default to 5 seconds.
 DEJACODE_INTEGRATION_REQUESTS_TIMEOUT = env.int("DEJACODE_INTEGRATION_REQUESTS_TIMEOUT", default=5)
+CREATE_DEPENDENCIES_DEFAULT = env.bool("CREATE_DEPENDENCIES_DEFAULT", default=True)
 
 if IS_TESTS:
     # Silent the django-axes logging during tests

--- a/product_portfolio/forms.py
+++ b/product_portfolio/forms.py
@@ -9,6 +9,7 @@
 import json
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.forms import BaseModelFormSet
@@ -557,7 +558,7 @@ class ImportFromScanForm(forms.Form):
     create_dependencies = forms.BooleanField(
         label=_("Create Dependencies"),
         required=False,
-        initial=False,
+        initial=settings.CREATE_DEPENDENCIES_DEFAULT,
         help_text=_(
             "When checked, dependency relationships between packages discovered in the "
             "import will be created on the Product."
@@ -664,7 +665,7 @@ class BaseProductImportFormView(forms.Form):
     create_dependencies = forms.BooleanField(
         label=_("Create Dependencies"),
         required=False,
-        initial=False,
+        initial=settings.CREATE_DEPENDENCIES_DEFAULT,
         help_text=_(
             "When checked, dependency relationships between packages discovered in the "
             "import will be created on the Product."
@@ -1002,7 +1003,7 @@ class PullProjectDataForm(forms.Form):
     create_dependencies = forms.BooleanField(
         label=_("Create Dependencies"),
         required=False,
-        initial=False,
+        initial=settings.CREATE_DEPENDENCIES_DEFAULT,
         help_text=_(
             "When checked, dependency relationships between packages discovered in the "
             "import will be created on the Product."

--- a/product_portfolio/importers.py
+++ b/product_portfolio/importers.py
@@ -10,6 +10,7 @@ import json
 import logging
 import time
 from collections import defaultdict
+from contextlib import contextmanager
 from contextlib import suppress
 
 from django import forms
@@ -687,6 +688,7 @@ class ImportPackageFromScanCodeIO:
         self.package_uid_mapping = {}
 
         self.user = user
+        self.dataspace = product.dataspace
         self.project_uuid = project_uuid
         self.product = product
         self.update_existing = update_existing
@@ -694,25 +696,22 @@ class ImportPackageFromScanCodeIO:
         self.infer_download_urls = infer_download_urls
         self.create_dependencies = create_dependencies
 
-        # Pre-fetch once to avoid repeated DB lookups in DefaultOnAdditionMixin.save().
-        dataspace = product.dataspace
-        self.default_review_status = ProductRelationStatus.objects.get_default_on_addition_qs(
-            dataspace
-        ).first()
-        self.default_purpose = ProductItemPurpose.objects.get_default_on_addition_qs(
-            dataspace
-        ).first()
+    def save(self):
+        save_start = time.perf_counter()
 
-        scancodeio = ScanCodeIO(user.dataspace)
+        scancodeio = ScanCodeIO(self.dataspace)
+
+        step_start = time.perf_counter()
         self.packages = scancodeio.fetch_project_packages(self.project_uuid)
+        logger.info(f"fetch_project_packages: {time.perf_counter() - step_start:.1f}s")
+
         if not self.packages:
             raise Exception("Packages could not be fetched from ScanCode.io")
 
         if self.create_dependencies:
+            step_start = time.perf_counter()
             self.dependencies = scancodeio.fetch_project_dependencies(self.project_uuid)
-
-    def save(self):
-        save_start = time.perf_counter()
+            logger.info(f"fetch_project_dependencies: {time.perf_counter() - step_start:.1f}s")
 
         step_start = time.perf_counter()
         self.import_packages()
@@ -737,6 +736,14 @@ class ImportPackageFromScanCodeIO:
         return dict(self.created), dict(self.existing), dict(self.errors)
 
     def import_packages(self):
+        # Pre-fetch once to avoid repeated DB lookups in DefaultOnAdditionMixin.save().
+        self.default_review_status = ProductRelationStatus.objects.get_default_on_addition_qs(
+            self.dataspace
+        ).first()
+        self.default_purpose = ProductItemPurpose.objects.get_default_on_addition_qs(
+            self.dataspace
+        ).first()
+
         for package_data in self.packages:
             self.import_package(package_data)
 

--- a/product_portfolio/importers.py
+++ b/product_portfolio/importers.py
@@ -54,6 +54,14 @@ from product_portfolio.models import ScanCodeProject
 logger = logging.getLogger(__name__)
 
 
+@contextmanager
+def log_elapsed(label):
+    """Context manager that logs the elapsed time of the wrapped block."""
+    start = time.perf_counter()
+    yield
+    logger.info(f"{label}: {time.perf_counter() - start:.1f}s")
+
+
 class CleanProductMixin(ComponentRelatedFieldImportMixin):
     def clean_product(self):
         queryset = Product.objects.get_queryset(self.user)
@@ -701,35 +709,30 @@ class ImportPackageFromScanCodeIO:
 
         scancodeio = ScanCodeIO(self.dataspace)
 
-        step_start = time.perf_counter()
-        self.packages = scancodeio.fetch_project_packages(self.project_uuid)
-        logger.info(f"fetch_project_packages: {time.perf_counter() - step_start:.1f}s")
+        with log_elapsed("fetch_project_packages"):
+            self.packages = scancodeio.fetch_project_packages(self.project_uuid)
 
         if not self.packages:
             raise Exception("Packages could not be fetched from ScanCode.io")
 
         if self.create_dependencies:
-            step_start = time.perf_counter()
-            self.dependencies = scancodeio.fetch_project_dependencies(self.project_uuid)
-            logger.info(f"fetch_project_dependencies: {time.perf_counter() - step_start:.1f}s")
+            with log_elapsed("fetch_project_dependencies"):
+                self.dependencies = scancodeio.fetch_project_dependencies(self.project_uuid)
 
-        step_start = time.perf_counter()
-        self.import_packages()
-        logger.info(f"import_packages: {time.perf_counter() - step_start:.1f}s")
+        with log_elapsed("import_packages"):
+            self.import_packages()
 
         if self.create_dependencies:
-            step_start = time.perf_counter()
-            self.import_dependencies()
-            logger.info(f"import_dependencies: {time.perf_counter() - step_start:.1f}s")
+            with log_elapsed("import_dependencies"):
+                self.import_dependencies()
 
         if self.scan_all_packages:
             transaction.on_commit(lambda: self.product.scan_all_packages_task(self.user))
             logger.info("scan_all_packages: scheduled")
 
         if self.user.dataspace.enable_vulnerablecodedb_access:
-            step_start = time.perf_counter()
-            self.product.fetch_vulnerabilities()
-            logger.info(f"fetch_vulnerabilities: {time.perf_counter() - step_start:.1f}s")
+            with log_elapsed("fetch_vulnerabilities"):
+                self.product.fetch_vulnerabilities()
 
         logger.info(f"save total: {time.perf_counter() - save_start:.1f}s")
 

--- a/product_portfolio/importers.py
+++ b/product_portfolio/importers.py
@@ -690,13 +690,7 @@ class ImportPackageFromScanCodeIO:
         self.infer_download_urls = infer_download_urls
         self.create_dependencies = create_dependencies
 
-        scancodeio = ScanCodeIO(user.dataspace)
-        self.packages = scancodeio.fetch_project_packages(self.project_uuid)
-        self.dependencies = scancodeio.fetch_project_dependencies(self.project_uuid)
-
-        if not self.packages and not self.dependencies:
-            raise Exception("Packages could not be fetched from ScanCode.io")
-
+        # Pre-fetch once to avoid repeated DB lookups in DefaultOnAdditionMixin.save().
         dataspace = product.dataspace
         self.default_review_status = ProductRelationStatus.objects.get_default_on_addition_qs(
             dataspace
@@ -704,6 +698,14 @@ class ImportPackageFromScanCodeIO:
         self.default_purpose = ProductItemPurpose.objects.get_default_on_addition_qs(
             dataspace
         ).first()
+
+        scancodeio = ScanCodeIO(user.dataspace)
+        self.packages = scancodeio.fetch_project_packages(self.project_uuid)
+        if not self.packages:
+            raise Exception("Packages could not be fetched from ScanCode.io")
+
+        if self.create_dependencies:
+            self.dependencies = scancodeio.fetch_project_dependencies(self.project_uuid)
 
     def save(self):
         self.import_packages()

--- a/product_portfolio/importers.py
+++ b/product_portfolio/importers.py
@@ -693,11 +693,21 @@ class ImportPackageFromScanCodeIO:
         scancodeio = ScanCodeIO(user.dataspace)
         self.packages = scancodeio.fetch_project_packages(self.project_uuid)
         self.dependencies = scancodeio.fetch_project_dependencies(self.project_uuid)
+
         if not self.packages and not self.dependencies:
             raise Exception("Packages could not be fetched from ScanCode.io")
 
+        dataspace = product.dataspace
+        self.default_review_status = ProductRelationStatus.objects.get_default_on_addition_qs(
+            dataspace
+        ).first()
+        self.default_purpose = ProductItemPurpose.objects.get_default_on_addition_qs(
+            dataspace
+        ).first()
+
     def save(self):
         self.import_packages()
+
         if self.create_dependencies:
             self.import_dependencies()
 
@@ -780,8 +790,11 @@ class ImportPackageFromScanCodeIO:
                 "license_expression": package.license_expression,
                 "notes": "Imported from ScanCode.io",
                 "created_by": self.user,
+                "review_status": self.default_review_status,
+                "purpose": self.default_purpose,
             },
         )
+
         package_uid = package_data.get("package_uid") or package.uuid
         self.package_uid_mapping[package_uid] = package
 
@@ -846,7 +859,7 @@ class ImportPackageFromScanCodeIO:
             return package
 
         # 2. If the package data does not include a download_url value:
-        # Attemp to find an existing package using purl-only match.
+        # Attempt to find an existing package using purl-only match.
         if not package_data.get("download_url"):
             purl_lookups = {field: package_data.get(field, "") for field in PACKAGE_URL_FIELDS}
             same_purl_packages = package_qs.filter(**purl_lookups)

--- a/product_portfolio/importers.py
+++ b/product_portfolio/importers.py
@@ -7,6 +7,8 @@
 #
 
 import json
+import logging
+import time
 from collections import defaultdict
 from contextlib import suppress
 
@@ -47,6 +49,8 @@ from product_portfolio.models import ProductItemPurpose
 from product_portfolio.models import ProductPackage
 from product_portfolio.models import ProductRelationStatus
 from product_portfolio.models import ScanCodeProject
+
+logger = logging.getLogger(__name__)
 
 
 class CleanProductMixin(ComponentRelatedFieldImportMixin):
@@ -708,16 +712,27 @@ class ImportPackageFromScanCodeIO:
             self.dependencies = scancodeio.fetch_project_dependencies(self.project_uuid)
 
     def save(self):
+        save_start = time.perf_counter()
+
+        step_start = time.perf_counter()
         self.import_packages()
+        logger.info(f"import_packages: {time.perf_counter() - step_start:.1f}s")
 
         if self.create_dependencies:
+            step_start = time.perf_counter()
             self.import_dependencies()
+            logger.info(f"import_dependencies: {time.perf_counter() - step_start:.1f}s")
 
         if self.scan_all_packages:
             transaction.on_commit(lambda: self.product.scan_all_packages_task(self.user))
+            logger.info("scan_all_packages: scheduled")
 
         if self.user.dataspace.enable_vulnerablecodedb_access:
+            step_start = time.perf_counter()
             self.product.fetch_vulnerabilities()
+            logger.info(f"fetch_vulnerabilities: {time.perf_counter() - step_start:.1f}s")
+
+        logger.info(f"save total: {time.perf_counter() - save_start:.1f}s")
 
         return dict(self.created), dict(self.existing), dict(self.errors)
 

--- a/product_portfolio/importers.py
+++ b/product_portfolio/importers.py
@@ -804,8 +804,9 @@ class ImportPackageFromScanCodeIO:
         if not package:
             try:
                 package = Package.create_from_data(self.user, package_data, validate=True)
-            except ValidationError as errors:
-                self.errors["package"].append(str(errors))
+            except ValidationError as error:
+                logger.error(f"Failed to create package: {error}\n{package_data}")
+                self.errors["package"].append(str(error))
                 return
             self.created["package"].append(str(package))
 


### PR DESCRIPTION
Following https://github.com/aboutcode-org/dejacode/pull/540

The `create_dependencies` boolean field now default to True (as it used to be) and can be controlled using the `CREATE_DEPENDENCIES_DEFAULT=False` setting.