### PR TITLE
fix: Package.get_purldb_entries() built a purl payload but placed it

### DIFF
--- a/component_catalog/models.py
+++ b/component_catalog/models.py
@@ -2585,10 +2585,13 @@ class Package(
         3. Package URL - Broadest match, may return multiple versions/variants
 
         A `max_request_call` integer can be provided to limit the number of
-        HTTP requests made to the PackageURL server.
+        HTTP requests made to the PackageURL server for the hash and download
+        URL fields.
         By default, one request will be made per field until a match is found.
         Providing max_request_call=1 will stop after the first request, even
         is nothing was found.
+        The Package URL is always used as a final fallback, regardless of
+        `max_request_call`, as it is the broadest match available.
         """
         payloads = []
         purldb_entries = []
@@ -2602,16 +2605,17 @@ class Package(
             payloads.append({"md5": self.md5})
         if self.download_url:
             payloads.append({"download_url": self.download_url})
-        if package_url:
-            payloads.append({"purl": package_url})
 
         purldb = PurlDB(user.dataspace)
         for index, payload in enumerate(payloads):
             if max_request_call and index >= max_request_call:
-                return
+                break
 
             if purldb_entries := purldb.find_packages(payload, timeout):
                 break
+
+        if not purldb_entries and package_url:
+            purldb_entries = purldb.find_packages({"purl": package_url}, timeout)
 
         if not purldb_entries:
             return []

--- a/component_catalog/tests/test_models.py
+++ b/component_catalog/tests/test_models.py
@@ -2632,6 +2632,37 @@ class ComponentCatalogModelsTestCase(TestCase):
         self.assertEqual([purldb_entry1, purldb_entry2], purldb_entries)
 
     @mock.patch("dejacode_toolkit.purldb.PurlDB.find_packages")
+    def test_package_model_get_purldb_entries_max_request_call_purl_fallback(
+        self, mock_find_packages
+    ):
+        """
+        A Package without hashes, whose `download_url` does not match anything in
+        PurlDB, should still be matched on its `purl` even when `max_request_call`
+        limits the number of PurlDB requests. See #462.
+        """
+        purl1 = "pkg:golang/github.com/pkg/errors@0.9.1"
+        package1 = make_package(
+            self.dataspace,
+            package_url=purl1,
+            download_url="https://example.com/inferred/download/url",
+        )
+        purldb_entry1 = {
+            "purl": purl1,
+            "type": "golang",
+            "name": "errors",
+            "version": "0.9.1",
+        }
+
+        def find_packages_side_effect(payload, timeout=None):
+            if payload.get("purl") == purl1:
+                return [purldb_entry1]
+            return None
+
+        mock_find_packages.side_effect = find_packages_side_effect
+        purldb_entries = package1.get_purldb_entries(user=self.user, max_request_call=1)
+        self.assertEqual([purldb_entry1], purldb_entries)
+
+    @mock.patch("dejacode_toolkit.purldb.PurlDB.find_packages")
     def test_package_model_get_purldb_entries_plain_purls_equal(self, mock_find_packages):
         purl1 = "pkg:maven/core/jackson-core@2.18.3?type=jar"
         purl2 = "pkg:maven/core/jackson-core@2.18.3?classifier=sources&type=jar"


### PR DESCRIPTION
Fixes #462

## Summary
Package.get_purldb_entries() built a purl payload but placed it last in the request list, so the synchronous PurlDB tab view (which calls it with max_request_call=1) stopped after only trying hash/download_url and never attempted the purl match — even though update_from_purldb (used by 'Improve Packages from PurlDB') has no such limit and succeeds. Restructured the method to always try the purl payload as a final fallback regardless of max_request_call, since it's the broadest/cheapest match.

## Changes
- `component_catalog/models.py`
- `component_catalog/tests/test_models.py`

## How this was tested
Ran `the affected tests` locally.
